### PR TITLE
Override fabric8-client dependency version from spring-cloud-dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ reckon {
 ext {
 	springCloudVersion = '2021.0.4'
 	thunxVersion = '0.4.2'
+	set('kubernetes-fabric8-client.version', '6.2.0')
 }
 
 bootRun {
@@ -68,8 +69,7 @@ dependencies {
 	implementation "com.contentgrid.thunx:thunx-spring"
 	implementation "com.contentgrid.thunx:thunx-pdp-opa"
 
-	implementation 'io.fabric8:kubernetes-client:6.2.0'
-	implementation 'io.fabric8:kubernetes-model-common:6.2.0'
+	implementation 'io.fabric8:kubernetes-client'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Currently 2 of the fabric8 dependencies have version `6.2.0`, but most have version `5.10.2` due to the constraints from the spring-cloud-dependencies bom. 

Although the syntax is a little awkward, this is the correct way to pin the version of a managed dependency.