### PR TITLE
Create a RouteDefinitionLocator instead of a RouteLocator

### DIFF
--- a/src/main/java/eu/xenit/alfred/content/gateway/routing/ServiceTracker.java
+++ b/src/main/java/eu/xenit/alfred/content/gateway/routing/ServiceTracker.java
@@ -3,44 +3,53 @@ package eu.xenit.alfred.content.gateway.routing;
 import eu.xenit.alfred.content.gateway.servicediscovery.AppService;
 import eu.xenit.alfred.content.gateway.servicediscovery.ServiceAddedHandler;
 import eu.xenit.alfred.content.gateway.servicediscovery.ServiceDeletedHandler;
+import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.logging.Level;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
 import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
+import org.springframework.cloud.gateway.route.RouteDefinitionRepository;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.ApplicationEventPublisher;
 import reactor.core.publisher.Flux;
+import reactor.util.Loggers;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ServiceTracker implements ServiceAddedHandler, ServiceDeletedHandler, RouteLocator {
+public class ServiceTracker implements ServiceAddedHandler, ServiceDeletedHandler, RouteDefinitionLocator {
     private final ApplicationEventPublisher publisher;
     private final RouteLocatorBuilder routeLocatorBuilder;
 
     private final Map<String, AppService> services = new ConcurrentHashMap<>();
 
-    public Flux<Route> getRoutes() {
-        var builder = routeLocatorBuilder.routes();
+    private RouteDefinition createRouteDefinition(AppService appService) {
+        var routeDef = new RouteDefinition();
+        routeDef.setId("k8s-"+appService.id());
+        routeDef.setUri(URI.create(appService.serviceUrl()));
 
-        for (AppService service : services.values()) {
-            builder.route(service.id(), p -> p
-                    .host(service.hostname())
-                    .uri(service.serviceUrl())
-            );
-        }
+        var hostnamePredicate = new PredicateDefinition();
 
-        if (log.isDebugEnabled()) {
-            var routes = builder.build().getRoutes();
-            log.debug("Current routes: {}", routes.collectList().block());
-            return routes;
-        }
+        hostnamePredicate.setName("Host");
+        hostnamePredicate.addArg("patterns", appService.hostname());
+        routeDef.setPredicates(List.of(hostnamePredicate));
+        return routeDef;
+    }
 
-        return builder.build().getRoutes();
+    @Override
+    public Flux<RouteDefinition> getRouteDefinitions() {
+        return Flux.fromStream(() -> services.values().stream()
+                .map(this::createRouteDefinition)
+        ).log(Loggers.getLogger(ServiceTracker.class), Level.FINE, false);
     }
 
     @Override
@@ -58,4 +67,5 @@ public class ServiceTracker implements ServiceAddedHandler, ServiceDeletedHandle
     public Stream<AppService> findServices(Predicate<AppService> predicate) {
         return services.values().stream().filter(predicate);
     }
+
 }


### PR DESCRIPTION
When using RouteDefinitionLocator instead of a RouteLocator, we get more goodies, like the default-filters being applied to all created routes
