### PR TITLE
Use the Spring Cloud managed depdency 'io.fabric8:kubernetes-client`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,7 @@ dependencies {
 	implementation "com.contentgrid.thunx:thunx-spring"
 	implementation "com.contentgrid.thunx:thunx-pdp-opa"
 
-	implementation 'io.fabric8:kubernetes-client:6.2.0'
-	implementation 'io.fabric8:kubernetes-model-common:6.2.0'
+	implementation 'io.fabric8:kubernetes-client'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
Spring Cloud 2022.0.0 also happens to ships with version `6.2.0` of `io.fabric8:kubernetes-client`

This PR supersedes:
* https://github.com/xenit-eu/contentgrid-gateway/pull/64
* https://github.com/xenit-eu/contentgrid-gateway/pull/67
* https://github.com/xenit-eu/contentgrid-gateway/pull/68