### PR TITLE
Remove deprecated http tracing actuator

### DIFF
--- a/src/main/java/eu/xenit/alfred/content/gateway/GatewayApplication.java
+++ b/src/main/java/eu/xenit/alfred/content/gateway/GatewayApplication.java
@@ -35,8 +35,6 @@ import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.boot.actuate.metrics.MetricsEndpoint;
 import org.springframework.boot.actuate.metrics.export.prometheus.PrometheusScrapeEndpoint;
-import org.springframework.boot.actuate.trace.http.HttpTraceRepository;
-import org.springframework.boot.actuate.trace.http.InMemoryHttpTraceRepository;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -161,12 +159,6 @@ public class GatewayApplication {
                     });
         }
     }
-
-    @Bean
-    HttpTraceRepository traceRepository() {
-        return new InMemoryHttpTraceRepository();
-    }
-
     @Bean
     public ServerLogoutSuccessHandler logoutSuccessHandler(
             Optional<ReactiveClientRegistrationRepository> clientRegistrationRepository) {


### PR DESCRIPTION
Spring Boot 3.0 is removing the http tracing actuator with the new Micrometer Tracing framework.
This PR removes the current in-memory http tracing actuator