### PR TITLE
Runtime OAuth2 login should only match app-requests with app-id

### DIFF
--- a/src/main/java/eu/xenit/alfred/content/gateway/runtime/RuntimeRequestResolver.java
+++ b/src/main/java/eu/xenit/alfred/content/gateway/runtime/RuntimeRequestResolver.java
@@ -1,11 +1,21 @@
 package eu.xenit.alfred.content.gateway.runtime;
 
 import java.util.Optional;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher.MatchResult;
 import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
 
 public interface RuntimeRequestResolver {
 
     Optional<String> resolveApplicationId(ServerWebExchange exchange);
 
     Optional<String> resolveDeploymentId(ServerWebExchange exchange);
+
+    default ServerWebExchangeMatcher matcher() {
+        return exchange -> resolveApplicationId(exchange)
+                .map(appId -> MatchResult.match())
+                .orElse(MatchResult.notMatch());
+    }
+
 }


### PR DESCRIPTION
without this change, there is no fall-through possibility to a static oauth2-idp