### PR TITLE
GHA: skip sonar check when SONAR_TOKEN is not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: ./gradlew check --info
       - name: Sonar Analysis
         run: ./gradlew sonar --info
+        if: env.SONAR_TOKEN != null
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Problem: dependabot PRs fail to send analysis to SonarCloud, because `SONAR_TOKEN` is not set.
Solution: skip GHA step for sonar analysis, when the secret does not exists.

Yes, I validated the `if` condition works correctly in both cases