### PR TITLE
Hide request-routing logic behind strategy-interface

### DIFF
--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
@@ -3,23 +3,23 @@ package com.contentgrid.gateway.runtime;
 import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter.CONTENTGRID_WEB_FILTER_CHAIN_FILTER_ORDER;
 
 import com.contentgrid.gateway.ServiceDiscoveryProperties;
+import com.contentgrid.gateway.runtime.application.ContentGridApplicationMetadata;
+import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.application.ServiceTracker;
 import com.contentgrid.gateway.runtime.application.SimpleContentGridApplicationMetadata;
 import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
-import com.contentgrid.gateway.runtime.routing.SimpleContentGridRequestRouter;
-import com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter;
-import com.contentgrid.gateway.runtime.web.ContentGridResponseHeadersWebFilter;
-import com.contentgrid.gateway.runtime.application.ServiceTracker;
 import com.contentgrid.gateway.runtime.config.ComposableApplicationConfigurationRepository;
 import com.contentgrid.gateway.runtime.config.kubernetes.Fabric8ConfigMapMapper;
 import com.contentgrid.gateway.runtime.config.kubernetes.Fabric8SecretMapper;
 import com.contentgrid.gateway.runtime.config.kubernetes.KubernetesResourceWatcherBinding;
-import com.contentgrid.gateway.runtime.application.ContentGridApplicationMetadata;
-import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.routing.ContentGridRequestRouter;
+import com.contentgrid.gateway.runtime.routing.SimpleContentGridRequestRouter;
 import com.contentgrid.gateway.runtime.servicediscovery.KubernetesServiceDiscovery;
 import com.contentgrid.gateway.runtime.servicediscovery.ServiceDiscovery;
+import com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter;
+import com.contentgrid.gateway.runtime.web.ContentGridResponseHeadersWebFilter;
 import com.contentgrid.thunx.pdp.opa.OpaQueryProvider;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import com.contentgrid.gateway.runtime.routing.ContentGridRequestRouter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.ApplicationRunner;
@@ -145,6 +145,4 @@ public class RuntimeConfiguration {
 
         }
     }
-
-
 }

--- a/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/KubernetesLabels.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/KubernetesLabels.java
@@ -9,7 +9,6 @@ public class KubernetesLabels {
     public static final String CONTENTGRID_SERVICETYPE = "app.contentgrid.com/service-type";
     public static final String CONTENTGRID_APPID = "app.contentgrid.com/application-id";
     public static final String CONTENTGRID_DEPLOYID = "app.contentgrid.com/deployment-id";
-
     public static final String CONTENTGRID_POLICYPACKAGE = "authz.contentgrid.com/policy-package";
 
 }

--- a/src/main/java/com/contentgrid/gateway/runtime/routing/ContentGridRequestRouter.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/routing/ContentGridRequestRouter.java
@@ -1,0 +1,14 @@
+package com.contentgrid.gateway.runtime.routing;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Strategy interface to select an appropriate {@link ServiceInstance} for a given {@link ServerWebExchange}.
+ */
+public interface ContentGridRequestRouter {
+
+    Mono<ServiceInstance> route(ServerWebExchange serverWebExchange);
+
+}

--- a/src/main/java/com/contentgrid/gateway/runtime/routing/SimpleContentGridRequestRouter.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/routing/SimpleContentGridRequestRouter.java
@@ -1,0 +1,61 @@
+package com.contentgrid.gateway.runtime.routing;
+
+import com.contentgrid.gateway.runtime.application.ContentGridApplicationMetadata;
+import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.application.ServiceTracker;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class SimpleContentGridRequestRouter implements ContentGridRequestRouter {
+
+    private final ServiceTracker serviceTracker;
+    private final ContentGridApplicationMetadata applicationMetadata;
+    private final ContentGridDeploymentMetadata serviceMetadata;
+
+    public SimpleContentGridRequestRouter(ServiceTracker serviceTracker,
+            ContentGridApplicationMetadata applicationMetadata,
+            ContentGridDeploymentMetadata serviceMetadata) {
+        this.serviceTracker = serviceTracker;
+        this.applicationMetadata = applicationMetadata;
+        this.serviceMetadata = serviceMetadata;
+    }
+
+    @Override
+    public Mono<ServiceInstance> route(ServerWebExchange exchange) {
+        var candidates = this.findAppServices(exchange);
+        var selection = this.selectService(exchange, candidates);
+        return Mono.justOrEmpty(selection);
+    }
+
+    private Set<ServiceInstance> findAppServices(ServerWebExchange exchange) {
+        return serviceTracker.services().filter(service -> {
+            var requestHost = exchange.getRequest().getURI().getHost();
+
+            var domains = applicationMetadata.getDomainNames(service);
+            return domains.contains(requestHost.toLowerCase(Locale.ROOT));
+        }).collect(Collectors.toSet());
+    }
+
+    private Optional<ServiceInstance> selectService(ServerWebExchange exchange, Set<ServiceInstance> candidates) {
+
+        if (candidates.size() > 1) {
+            // logging a warning until we have a better service selection
+            log.warn("multiple matches {}: {}", exchange.getRequest().getURI().getHost(), candidates.stream()
+                    .map(service -> serviceMetadata.getDeploymentId(service).orElse("<none>")).toList());
+        }
+
+        // sorting based on deployment-id alphabetical order, to get at least a stable selection
+        return candidates.stream().min((service1, service2) -> {
+            var d1 = serviceMetadata.getDeploymentId(service1).orElse("");
+            var d2 = serviceMetadata.getDeploymentId(service2).orElse("");
+            return d1.compareTo(d2);
+        });
+    }
+}

--- a/src/test/java/com/contentgrid/gateway/runtime/ServiceInstanceStubs.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/ServiceInstanceStubs.java
@@ -1,5 +1,7 @@
-package com.contentgrid.gateway.runtime.application;
+package com.contentgrid.gateway.runtime;
 
+import com.contentgrid.gateway.runtime.application.ApplicationId;
+import com.contentgrid.gateway.runtime.application.DeploymentId;
 import com.contentgrid.gateway.runtime.config.kubernetes.KubernetesLabels;
 import java.util.Map;
 import java.util.UUID;
@@ -9,13 +11,17 @@ import org.springframework.cloud.client.DefaultServiceInstance;
 import org.springframework.cloud.client.ServiceInstance;
 
 @UtilityClass
-class ServiceInstanceStubs {
+public class ServiceInstanceStubs {
 
-    static ServiceInstance serviceInstance(ApplicationId applicationId) {
+    public static ServiceInstance serviceInstance(ApplicationId applicationId) {
         return serviceInstance(DeploymentId.random(), applicationId, randomPolicyPackage());
     }
 
-    static ServiceInstance serviceInstance(
+    public static ServiceInstance serviceInstance(DeploymentId deploymentId, ApplicationId applicationId) {
+        return serviceInstance(deploymentId, applicationId, randomPolicyPackage());
+    }
+
+    public static ServiceInstance serviceInstance(
             @NonNull DeploymentId deploymentId,
             @NonNull ApplicationId applicationId,
             @NonNull String policyPackage) {
@@ -37,7 +43,7 @@ class ServiceInstanceStubs {
     }
 
     @NonNull
-    static String randomPolicyPackage() {
+    public static String randomPolicyPackage() {
         return "contentgrid.userapps.x" + UUID.randomUUID().toString().replaceAll("-", "");
     }
 }

--- a/src/test/java/com/contentgrid/gateway/runtime/application/SimpleContentGridApplicationMetadataTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/application/SimpleContentGridApplicationMetadataTest.java
@@ -1,8 +1,8 @@
 package com.contentgrid.gateway.runtime.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
+import com.contentgrid.gateway.runtime.ServiceInstanceStubs;
 import org.junit.jupiter.api.Test;
 
 class SimpleContentGridApplicationMetadataTest {

--- a/src/test/java/com/contentgrid/gateway/runtime/application/SimpleContentGridDeploymentMetadataTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/application/SimpleContentGridDeploymentMetadataTest.java
@@ -2,6 +2,7 @@ package com.contentgrid.gateway.runtime.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.contentgrid.gateway.runtime.ServiceInstanceStubs;
 import org.junit.jupiter.api.Test;
 
 class SimpleContentGridDeploymentMetadataTest {

--- a/src/test/java/com/contentgrid/gateway/runtime/routing/SimpleContentGridRequestRouterTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/routing/SimpleContentGridRequestRouterTest.java
@@ -1,0 +1,76 @@
+package com.contentgrid.gateway.runtime.routing;
+
+import static com.contentgrid.gateway.test.assertj.MonoAssert.assertThat;
+
+import com.contentgrid.gateway.runtime.application.ApplicationId;
+import com.contentgrid.gateway.runtime.application.ContentGridApplicationMetadata;
+import com.contentgrid.gateway.runtime.application.DeploymentId;
+import com.contentgrid.gateway.runtime.application.ServiceTracker;
+import com.contentgrid.gateway.runtime.application.SimpleContentGridApplicationMetadata;
+import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.config.kubernetes.KubernetesLabels;
+import java.util.Map;
+import java.util.UUID;
+import lombok.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.DefaultServiceInstance;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+class SimpleContentGridRequestRouterTest {
+
+    protected ContentGridApplicationMetadata applicationMetadata;
+    protected ServiceTracker serviceTracker;
+
+    protected ContentGridRequestRouter requestRouter;
+
+    @BeforeEach
+    void setup() {
+        var deployMetadata = new SimpleContentGridDeploymentMetadata();
+        this.applicationMetadata = new SimpleContentGridApplicationMetadata(deployMetadata);
+        this.serviceTracker = new ServiceTracker(event -> { }, applicationMetadata);
+        this.requestRouter = new SimpleContentGridRequestRouter(this.serviceTracker, this.applicationMetadata, deployMetadata);
+    }
+
+    @Test
+    void test() {
+        var deployId = DeploymentId.random();
+        var appId = ApplicationId.random();
+
+        var exchange1 = createExchange("https://{appId}.userapps.contentgrid.com/me", appId);
+        assertThat(this.requestRouter.route(exchange1)).isEmptyMono();
+
+
+        var service = serviceInstance(deployId, appId);
+
+        this.serviceTracker.handleServiceAdded(service);
+
+        var exchange2 = createExchange("https://{appId}.userapps.contentgrid.com/me", appId);
+        assertThat(this.requestRouter.route(exchange2)).hasValue();
+    }
+
+    @NonNull
+    private static MockServerWebExchange createExchange(String uriTemplate, Object... uriVars) {
+        return MockServerWebExchange.from(MockServerHttpRequest.get(uriTemplate, uriVars).build());
+    }
+
+    private static ServiceInstance serviceInstance(DeploymentId deploymentId, ApplicationId applicationId) {
+        var serviceName = "api-d-%s".formatted(deploymentId.toString());
+        var host = "%s.default.svc.cluster.local".formatted(serviceName);
+        return new DefaultServiceInstance(
+                UUID.randomUUID().toString(),
+                serviceName,
+                host,
+                8080,
+                false,
+                Map.of(
+                        KubernetesLabels.CONTENTGRID_APPID, applicationId.toString(),
+                        KubernetesLabels.CONTENTGRID_DEPLOYID, deploymentId.toString(),
+                        KubernetesLabels.CONTENTGRID_SERVICETYPE, "api"
+                )
+        );
+    }
+
+}

--- a/src/test/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilterTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilterTest.java
@@ -1,0 +1,78 @@
+package com.contentgrid.gateway.runtime.web;
+
+import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter.CONTENTGRID_APP_ID_ATTR;
+import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter.CONTENTGRID_DEPLOY_ID_ATTR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.contentgrid.gateway.runtime.ServiceInstanceStubs;
+import com.contentgrid.gateway.runtime.application.ApplicationId;
+import com.contentgrid.gateway.runtime.application.DeploymentId;
+import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.routing.ContentGridRequestRouter;
+import lombok.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ContentGridAppRequestWebFilterTest {
+
+    private SimpleContentGridDeploymentMetadata serviceMetadata = new SimpleContentGridDeploymentMetadata();
+    private ContentGridRequestRouter requestRouter;
+    private WebFilterChain chain;
+
+    @BeforeEach
+    void setup() {
+        this.requestRouter = Mockito.mock(ContentGridRequestRouter.class);
+        this.chain = Mockito.mock(WebFilterChain.class);
+
+        Mockito.when(chain.filter(any(ServerWebExchange.class))).thenReturn(Mono.empty());
+    }
+
+    @Test
+    void matchingRoute_hasAttributes() {
+        var appId = ApplicationId.random();
+        var deploymentId = DeploymentId.random();
+        Mockito.when(requestRouter.route(any(ServerWebExchange.class)))
+                .thenReturn(Mono.just(ServiceInstanceStubs.serviceInstance(deploymentId, appId)));
+
+        var filter = new ContentGridAppRequestWebFilter(serviceMetadata, requestRouter);
+
+        var request = createExchange(appId);
+        var result = filter.filter(request, chain);
+
+        StepVerifier.create(result).verifyComplete();
+
+        assertThat(request.getAttributes()).containsEntry(CONTENTGRID_APP_ID_ATTR, appId.toString());
+        assertThat(request.getAttributes()).containsEntry(CONTENTGRID_DEPLOY_ID_ATTR, deploymentId.toString());
+    }
+
+    @Test
+    void noMatchingRoute_hasNoAttributes() {
+        var appId = ApplicationId.random();
+        var deploymentId = DeploymentId.random();
+        Mockito.when(requestRouter.route(any(ServerWebExchange.class))).thenReturn(Mono.empty());
+
+        var filter = new ContentGridAppRequestWebFilter(serviceMetadata, requestRouter);
+
+        var request = createExchange(appId);
+        var result = filter.filter(request, chain);
+
+        StepVerifier.create(result).verifyComplete();
+
+        assertThat(request.getAttributes()).doesNotContainKey(CONTENTGRID_APP_ID_ATTR);
+        assertThat(request.getAttributes()).doesNotContainKey(CONTENTGRID_DEPLOY_ID_ATTR);
+    }
+
+    @NonNull
+    private static MockServerWebExchange createExchange(ApplicationId appId) {
+        var uriTemplate = "https://{appId}.userapps.contentgrid.com/me";
+        return MockServerWebExchange.from(MockServerHttpRequest.get(uriTemplate, appId).build());
+    }
+}

--- a/src/test/java/com/contentgrid/gateway/test/assertj/MonoAssert.java
+++ b/src/test/java/com/contentgrid/gateway/test/assertj/MonoAssert.java
@@ -25,4 +25,10 @@ public class MonoAssert<T> extends AbstractAssert<MonoAssert<T>, Mono<T>> {
         StepVerifier.create(actual).expectNext(value).verifyComplete();
         return this;
     }
+
+    public MonoAssert<T> hasValue() {
+        this.isNotNull();
+        StepVerifier.create(actual).expectNextCount(1).verifyComplete();
+        return this;
+    }
 }


### PR DESCRIPTION
This PR extracts the current (temporary) routing logic from `ContentGridAppRequestWebFilter` and hides it behind a new strategy interface named `ContentGridRequestRouter`