### PR TITLE
ApplicationId and DeploymentId .from(String) should not return an Optional

### DIFF
--- a/src/main/java/com/contentgrid/gateway/runtime/application/ApplicationId.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/application/ApplicationId.java
@@ -7,6 +7,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 @EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -21,12 +23,9 @@ public class ApplicationId {
         return this.getValue();
     }
 
-    public static Optional<ApplicationId> from(@NonNull String value) {
-        if (value.isBlank()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new ApplicationId(value));
+    public static ApplicationId from(@NonNull String value) {
+        Assert.hasText(value, "'value' must not be empty");
+        return new ApplicationId(value);
     }
 
     public static ApplicationId random() {

--- a/src/main/java/com/contentgrid/gateway/runtime/application/DeploymentId.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/application/DeploymentId.java
@@ -7,6 +7,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.Assert;
 
 @EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -21,12 +22,9 @@ public class DeploymentId {
         return this.getValue();
     }
 
-    public static Optional<DeploymentId> from(@NonNull String value) {
-        if (value.isBlank()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new DeploymentId(value));
+    public static DeploymentId from(@NonNull String value) {
+        Assert.hasText(value, "'value' must not be empty");
+        return new DeploymentId(value);
     }
 
     public static DeploymentId random() {

--- a/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8ConfigMapMapper.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8ConfigMapMapper.java
@@ -15,7 +15,7 @@ public class Fabric8ConfigMapMapper implements KubernetesResourceMapper<ConfigMa
         var appIdLabel = configMap.getMetadata().getLabels().get(KubernetesLabels.CONTENTGRID_APPID);
 
         return Optional.ofNullable(appIdLabel)
-                .flatMap(ApplicationId::from)
+                .map(ApplicationId::from)
                 .map(appId -> new ApplicationConfigurationFragment(fragmentId, appId, configMap.getData()))
                 .or(() -> {
                     log.warn("{} {} has no valid label '{}'",

--- a/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8SecretMapper.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8SecretMapper.java
@@ -20,7 +20,7 @@ public class Fabric8SecretMapper implements KubernetesResourceMapper<Secret> {
 
         var labels = secret.getMetadata().getLabels();
         var fragment = Optional.ofNullable(labels.get(APP_ID_LABEL))
-                .flatMap(ApplicationId::from)
+                .map(ApplicationId::from)
                 .map(appId -> new ApplicationConfigurationFragment(fragmentId, appId, base64decode(secret.getData())));
 
         if (fragment.isEmpty()) {

--- a/src/main/java/com/contentgrid/gateway/runtime/routing/DefaultRuntimeRequestResolver.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/routing/DefaultRuntimeRequestResolver.java
@@ -14,13 +14,13 @@ public class DefaultRuntimeRequestResolver implements RuntimeRequestResolver {
     public Optional<ApplicationId> resolveApplicationId(ServerWebExchange exchange) {
         return Optional.ofNullable(exchange.getAttribute(CONTENTGRID_APP_ID_ATTR))
                 .map(Object::toString)
-                .flatMap(ApplicationId::from);
+                .map(ApplicationId::from);
     }
 
     @Override
     public Optional<DeploymentId> resolveDeploymentId(ServerWebExchange exchange) {
         return Optional.ofNullable(exchange.getAttribute(CONTENTGRID_DEPLOY_ID_ATTR))
                 .map(Object::toString)
-                .flatMap(DeploymentId::from);
+                .map(DeploymentId::from);
     }
 }

--- a/src/test/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8ConfigMapMapperTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/config/kubernetes/Fabric8ConfigMapMapperTest.java
@@ -16,7 +16,7 @@ class Fabric8ConfigMapMapperTest {
         var fragment = mapper.apply(Fixtures.configMap()).orElseThrow();
 
         assertThat(fragment.getApplicationId())
-                .isEqualTo(ApplicationId.from("f2c9cbef-dd86-4625-a805-28b65dd068cf").orElseThrow());
+                .isEqualTo(ApplicationId.from("f2c9cbef-dd86-4625-a805-28b65dd068cf"));
         assertThat(fragment.getProperty("contentgrid.routing.domains"))
                 .hasValue("f2c9cbef-dd86-4625-a805-28b65dd068cf.userapps.contentgrid.com");
     }

--- a/src/test/java/com/contentgrid/gateway/security/DynamicOidcAuthenticationIntegrationTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/DynamicOidcAuthenticationIntegrationTest.java
@@ -63,13 +63,13 @@ class DynamicOidcAuthenticationIntegrationTest extends AbstractKeycloakIntegrati
                 @Override
                 public Optional<ApplicationId> resolveApplicationId(ServerWebExchange exchange) {
                     var header = exchange.getRequest().getHeaders().getFirst("Test-ApplicationId");
-                    return Optional.ofNullable(header).flatMap(ApplicationId::from);
+                    return Optional.ofNullable(header).map(ApplicationId::from);
                 }
 
                 @Override
                 public Optional<DeploymentId> resolveDeploymentId(ServerWebExchange exchange) {
                     var header = exchange.getRequest().getHeaders().getFirst("Test-DeploymentId");
-                    return Optional.ofNullable(header).flatMap(DeploymentId::from);
+                    return Optional.ofNullable(header).map(DeploymentId::from);
                 }
             };
         }
@@ -153,8 +153,7 @@ class DynamicOidcAuthenticationIntegrationTest extends AbstractKeycloakIntegrati
         // HTTP 401 - request not associated with an app-id
         assertRequest_withBearer(null, tokenResponse.getAccessToken()).isUnauthorized();
         // HTTP 401 - access token cannot be associated with app-id
-        assertRequest_withBearer(ApplicationId.from("invalid").orElseThrow(),
-                tokenResponse.getAccessToken()).isUnauthorized();
+        assertRequest_withBearer(ApplicationId.from("invalid"), tokenResponse.getAccessToken()).isUnauthorized();
 
         // revoke app-id configuration
         applicationConfigurationRepository.remove(appId);


### PR DESCRIPTION
Correcting an earlier mistake:
* `ApplicationId.from(String)` should not return `Optional<ApplicationId>`, but just a plain `ApplicationId`
* `DeploymentId.from(String)` should not return `Optional<DeploymentId>`, but just a plain `DeploymentId`

*breaking change*: in case a blank string is passed as an argument, now an `IllegalArgumentException` is raised