### PR TITLE
Refactor structure given to OPA for authenticating a request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,6 @@ plugins {
 repositories {
 	mavenCentral()
 	maven { url 'https://repo.spring.io/milestone' }
-
-	maven {
-		url 'https://oss.sonatype.org/content/repositories/snapshots'
-		content {
-			includeGroup 'com.contentgrid.thunx'
-		}
-	}
 }
 
 bootRun {
@@ -65,7 +58,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-	implementation platform('com.contentgrid.thunx:thunx-bom:0.6.2')
+	implementation platform('com.contentgrid.thunx:thunx-bom:0.7.0')
 	implementation 'com.contentgrid.thunx:thunx-spring'
 	implementation 'com.contentgrid.thunx:thunx-pdp-opa'
 

--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
@@ -40,7 +40,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.server.ServerWebExchange;
 
 @Slf4j
 @Configuration(proxyBeanMethods = false)
@@ -118,7 +120,7 @@ public class RuntimeConfiguration {
     }
 
     @Bean
-    OpaQueryProvider opaQueryProvider(ServiceCatalog serviceCatalog, ContentGridDeploymentMetadata deploymentMetadata) {
+    OpaQueryProvider<ServerWebExchange> opaQueryProvider(ServiceCatalog serviceCatalog, ContentGridDeploymentMetadata deploymentMetadata) {
         return new RuntimeOpaQueryProvider(serviceCatalog, deploymentMetadata);
     }
 

--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeOpaQueryProvider.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeOpaQueryProvider.java
@@ -5,14 +5,15 @@ import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter
 import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
 import com.contentgrid.gateway.runtime.application.DeploymentId;
 import com.contentgrid.gateway.runtime.application.ServiceCatalog;
-import com.contentgrid.thunx.pdp.RequestContext;
 import com.contentgrid.thunx.pdp.opa.OpaQueryProvider;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.server.ServerWebExchange;
 
 @Slf4j
 @RequiredArgsConstructor
-public class RuntimeOpaQueryProvider implements OpaQueryProvider {
+public class RuntimeOpaQueryProvider implements OpaQueryProvider<ServerWebExchange> {
 
     private final ServiceCatalog serviceCatalog;
     private final ContentGridDeploymentMetadata deploymentMetadata;
@@ -20,15 +21,15 @@ public class RuntimeOpaQueryProvider implements OpaQueryProvider {
     final static String NO_MATCH_QUERY = "0 == 1";
 
     @Override
-    public String createQuery(RequestContext requestContext) {
+    public String createQuery(ServerWebExchange requestContext) {
 
-        return requestContext
-                .<DeploymentId>getAttribute(CONTENTGRID_DEPLOY_ID_ATTR)
+        return Optional.ofNullable(requestContext
+                .<DeploymentId>getAttribute(CONTENTGRID_DEPLOY_ID_ATTR))
                 .flatMap(serviceCatalog::findByDeploymentId)
                 .flatMap(deploymentMetadata::getPolicyPackage)
                 .map("data.%s.allow == true"::formatted)
                 .orElseGet(() -> {
-                    log.warn("No policy found for request to '{}'", requestContext.getURI().getHost());
+                    log.warn("No policy found for request to '{}'", requestContext.getRequest().getURI().getHost());
                     return NO_MATCH_QUERY;
                 });
     }

--- a/src/main/java/com/contentgrid/gateway/security/opa/AuthenticationModel.java
+++ b/src/main/java/com/contentgrid/gateway/security/opa/AuthenticationModel.java
@@ -1,0 +1,69 @@
+package com.contentgrid.gateway.security.opa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+@Value
+@Builder
+public class AuthenticationModel {
+    boolean authenticated;
+
+    Map<String, Object> principal;
+
+    String issuer;
+    @JsonProperty("authenticated_at")
+    Instant authenticatedAt;
+    String acr;
+
+    public static AuthenticationModel from(Authentication authenticationContext) {
+        var claims = extractClaims(authenticationContext);
+        return AuthenticationModel.builder()
+                .authenticated(!(authenticationContext instanceof AnonymousAuthenticationToken))
+                .principal(createPrincipal(claims))
+                .issuer(claims.getClaimAsString("iss"))
+                .authenticatedAt(claims.getClaimAsInstant("auth_time"))
+                .acr(claims.getClaimAsString("acr"))
+                .build();
+    }
+
+    private static Map<String, Object> createPrincipal(ClaimAccessor claims) {
+        var principal = new HashMap<String, Object>();
+
+        for (String claimName : claims.getClaims().keySet()) {
+            switch (claimName) {
+                case "preferred_username" -> principal.put("username", claims.getClaimAsString(claimName));
+                case "email", "sub" -> principal.put(claimName, claims.getClaimAsString(claimName));
+            }
+            if(claimName.startsWith("contentgrid:")) {
+                principal.put(claimName, claims.getClaim(claimName));
+            }
+        }
+
+        return principal;
+    }
+
+    private static ClaimAccessor extractClaims(Authentication authenticationContext) {
+        var principal = authenticationContext.getPrincipal();
+
+        if(principal instanceof ClaimAccessor claimAccessor) {
+            return claimAccessor;
+        }
+
+        // fallback to check authorities on the auth-object
+        var claims =  authenticationContext.getAuthorities().stream()
+                .filter(OAuth2UserAuthority.class::isInstance)
+                .map(OAuth2UserAuthority.class::cast)
+                .findAny()
+                .map(OAuth2UserAuthority::getAttributes)
+                .orElse(Map.of());
+        return () -> claims;
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/opa/ContentgridOpaInputProvider.java
+++ b/src/main/java/com/contentgrid/gateway/security/opa/ContentgridOpaInputProvider.java
@@ -1,0 +1,26 @@
+package com.contentgrid.gateway.security.opa;
+
+import com.contentgrid.thunx.pdp.opa.OpaInputProvider;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+
+public class ContentgridOpaInputProvider implements OpaInputProvider<Authentication, ServerWebExchange> {
+
+    @Override
+    public Map<String, Object> createInput(Authentication authenticationContext, ServerWebExchange requestContext) {
+        var request = RequestModel.from(requestContext);
+        var auth = AuthenticationModel.from(authenticationContext);
+        return Map.of(
+                "auth", auth,
+                "request", request,
+
+                // Deprecated input properties, for backwards compatibility with existing
+                // applications only
+                "method", request.getMethod(),
+                "path", request.getPath(),
+                "queryParams", request.getQuery(),
+                "user", auth.getPrincipal()
+        );
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/opa/ContentgridOpaInputProvider.java
+++ b/src/main/java/com/contentgrid/gateway/security/opa/ContentgridOpaInputProvider.java
@@ -9,7 +9,7 @@ public class ContentgridOpaInputProvider implements OpaInputProvider<Authenticat
 
     @Override
     public Map<String, Object> createInput(Authentication authenticationContext, ServerWebExchange requestContext) {
-        var request = RequestModel.from(requestContext);
+        var request = RequestModel.from(requestContext.getRequest());
         var auth = AuthenticationModel.from(authenticationContext);
         return Map.of(
                 "auth", auth,

--- a/src/main/java/com/contentgrid/gateway/security/opa/RequestModel.java
+++ b/src/main/java/com/contentgrid/gateway/security/opa/RequestModel.java
@@ -1,0 +1,46 @@
+package com.contentgrid.gateway.security.opa;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.web.server.ServerWebExchange;
+
+@Value
+@Builder
+public class RequestModel {
+    String method;
+    List<String> path;
+    Map<String, List<String>> query;
+    Map<String, List<String>> headers;
+
+    public static RequestModel from(ServerWebExchange requestContext) {
+        var request = requestContext.getRequest();
+        return RequestModel.builder()
+                .method(request.getMethod().name())
+                .path(List.of(uriToPathArray(request.getURI())))
+                .query(request.getQueryParams())
+                .headers(request.getHeaders())
+                .build();
+    }
+
+    private static String[] uriToPathArray(URI uri) {
+        uri = uri.normalize();
+
+        var path = uri.getPath();
+        if (path == null) {
+            return new String[0];
+        }
+
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+
+        if (path.length() == 0) {
+            return new String[0];
+        }
+
+        return path.split("/");
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/opa/RequestModel.java
+++ b/src/main/java/com/contentgrid/gateway/security/opa/RequestModel.java
@@ -2,10 +2,13 @@ package com.contentgrid.gateway.security.opa;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Value;
-import org.springframework.web.server.ServerWebExchange;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 
 @Value
 @Builder
@@ -15,13 +18,17 @@ public class RequestModel {
     Map<String, List<String>> query;
     Map<String, List<String>> headers;
 
-    public static RequestModel from(ServerWebExchange requestContext) {
-        var request = requestContext.getRequest();
+    public static RequestModel from(ServerHttpRequest request) {
         return RequestModel.builder()
                 .method(request.getMethod().name())
                 .path(List.of(uriToPathArray(request.getURI())))
                 .query(request.getQueryParams())
-                .headers(request.getHeaders())
+                .headers(
+                        request.getHeaders()
+                                .entrySet()
+                                .stream()
+                                .collect(Collectors.toMap(e -> e.getKey().toLowerCase(Locale.ROOT), Entry::getValue))
+                )
                 .build();
     }
 

--- a/src/test/java/com/contentgrid/gateway/runtime/RuntimeOpaQueryProviderTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/RuntimeOpaQueryProviderTest.java
@@ -9,8 +9,6 @@ import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata
 import com.contentgrid.gateway.runtime.application.DeploymentId;
 import com.contentgrid.gateway.runtime.application.ServiceCatalog;
 import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
-import com.contentgrid.thunx.pdp.RequestContext;
-import com.contentgrid.thunx.spring.security.ServerWebExchangeRequestContext;
 import java.util.Optional;
 import lombok.NonNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
 
 class RuntimeOpaQueryProviderTest {
 
@@ -84,12 +83,11 @@ class RuntimeOpaQueryProviderTest {
     }
 
     @NonNull
-    private static RequestContext createRequestContext(DeploymentId deployId) {
-        var request = MockServerHttpRequest.get("http://foo.userapps.contentgrid.com").build();
-        var exchange = MockServerWebExchange.from(request);
+    private static ServerWebExchange createRequestContext(DeploymentId deployId) {
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("http://foo.userapps.contentgrid.com").build());
         if (deployId != null) {
             exchange.getAttributes().put(CONTENTGRID_DEPLOY_ID_ATTR, deployId);
         }
-        return new ServerWebExchangeRequestContext(exchange);
+        return exchange;
     }
 }

--- a/src/test/java/com/contentgrid/gateway/security/opa/AuthenticationModelTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/opa/AuthenticationModelTest.java
@@ -1,0 +1,102 @@
+package com.contentgrid.gateway.security.opa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+
+class AuthenticationModelTest {
+
+    @Test
+    void fromOidcUser() {
+        var instant = Instant.now();
+
+        var idToken = OidcIdToken.withTokenValue("dummy")
+                .subject("04c2cbec-faad-4dc8-ba6f-edb3d5b902e9")
+                .claim("preferred_username", "alice")
+                .issuedAt(instant)
+                .expiresAt(instant.plus(5, ChronoUnit.MINUTES))
+                .authTime(instant)
+                // This is actually how we receive the issuer, as an URI
+                .claim(IdTokenClaimNames.ISS, URI.create("https://auth.contentgrid.com/auth/realms/my-org"))
+                .authorizedParty("contentgrid-gateway")
+                .build();
+        var userInfo = new OidcUserInfo(Map.of(
+                "contentgrid:custom", List.of("blue", "green"),
+                "email_verified", false
+        ));
+        var userRole = new OidcUserAuthority(idToken, userInfo);
+        var oidcUser = new DefaultOidcUser(Set.of(userRole), idToken, userInfo, "preferred_username");
+
+        var auth = new TestingAuthenticationToken(oidcUser, null, AuthorityUtils.NO_AUTHORITIES);
+
+        var model = AuthenticationModel.from(auth);
+
+        assertThat(model.isAuthenticated()).isEqualTo(true);
+
+        assertThat(model.getPrincipal()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "username", "alice",
+                "sub", idToken.getSubject(),
+                "contentgrid:custom", List.of("blue", "green")
+        ));
+
+        assertThat(model.getAuthenticatedAt()).isEqualTo(instant);
+        assertThat(model.getIssuer()).isEqualTo("https://auth.contentgrid.com/auth/realms/my-org");
+    }
+
+    @Test
+    void fromJwtAccessToken() {
+        var instant = Instant.now();
+
+        var jwtToken = new ClaimAccessor() {
+
+            @Override
+            public Map<String, Object> getClaims() {
+                return Map.of("sub", "04c2cbec-faad-4dc8-ba6f-edb3d5b902e9",
+                        "iat", instant,
+                        "preferred_username", "alice",
+                        "contentgrid:custom", List.of("blue", "green"),
+                        "email_verified", false
+                );
+
+            }
+        };
+        var auth = new TestingAuthenticationToken(jwtToken, null, AuthorityUtils.NO_AUTHORITIES);
+
+        var model = AuthenticationModel.from(auth);
+
+        assertThat(model.isAuthenticated()).isEqualTo(true);
+        assertThat(model.getPrincipal()).containsAllEntriesOf(Map.of(
+                "username", "alice",
+                "sub", "04c2cbec-faad-4dc8-ba6f-edb3d5b902e9",
+                "contentgrid:custom", List.of("blue", "green")
+        ));
+    }
+
+    @Test
+    void fromAnonymousAccessToken() {
+        var anonymousToken = new AnonymousAuthenticationToken("test", "anonymous", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        var model = AuthenticationModel.from(anonymousToken);
+
+        assertThat(model.isAuthenticated()).isFalse();
+        assertThat(model.getAuthenticatedAt()).isNull();
+        assertThat(model.getIssuer()).isNull();
+        assertThat(model.getAcr()).isNull();
+        assertThat(model.getPrincipal()).isEmpty();
+    }
+}

--- a/src/test/java/com/contentgrid/gateway/security/opa/RequestModelTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/opa/RequestModelTest.java
@@ -1,0 +1,60 @@
+package com.contentgrid.gateway.security.opa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+
+class RequestModelTest {
+    @Test
+    void createFromRequest() {
+
+        var request = MockServerHttpRequest.get("http://localhost:123/abc/123/")
+                .queryParam("xyz", "abc", "def")
+                .header("Content-Type", "application/json", "application/xml")
+                .build();
+
+        var model = RequestModel.from(request);
+
+        assertThat(model.getMethod()).isEqualTo("GET");
+        assertThat(model.getPath()).isEqualTo(List.of("abc", "123"));
+        assertThat(model.getQuery()).isEqualTo(Map.of("xyz", List.of("abc", "def")));
+        assertThat(model.getHeaders()).isEqualTo(Map.of("content-type",  List.of("application/json", "application/xml")));
+    }
+
+    @Test
+    void createFromRequestWithoutPath() {
+        var request = MockServerHttpRequest.get("http://localhost:123")
+                .build();
+
+        var model = RequestModel.from(request);
+
+        assertThat(model.getPath()).isEqualTo(List.of());
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void createFromRequestWithWeirdPath(String path, List<String> expected) {
+        var request = MockServerHttpRequest.get("http://localhost:123/"+path)
+                .build();
+
+        var model = RequestModel.from(request);
+
+        assertThat(model.getPath()).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> createFromRequestWithWeirdPath() {
+        return Stream.of(
+                Arguments.of("///abc", List.of("abc")),
+                Arguments.of("xyz/../def", List.of("def")),
+                Arguments.of("xyz/./", List.of("xyz")),
+                Arguments.of("xyz/./def", List.of("xyz", "def"))
+        );
+    }
+}


### PR DESCRIPTION
We now send an object using `input.request` and `input.auth` objects, instead of putting all information directly in the `input` object on the root.

Note that this requires thunx 0.7.0
