### PR TITLE
Do not log 'no route found' for actuator-requests

### DIFF
--- a/src/main/java/com/contentgrid/gateway/runtime/routing/DynamicVirtualHostResolver.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/routing/DynamicVirtualHostResolver.java
@@ -59,7 +59,7 @@ public class DynamicVirtualHostResolver implements RuntimeVirtualHostResolver {
 
         var registrations = this.lookupByDomain.apply(requestHost);
         if (registrations.isEmpty()) {
-            log.debug("resolving {} failed", requestHost);
+            log.debug("No app-domain-registration found for '{}'", requestHost);
             return Optional.empty();
         }
 
@@ -73,7 +73,7 @@ public class DynamicVirtualHostResolver implements RuntimeVirtualHostResolver {
         }
 
         var appId = registrations.iterator().next().applicationId();
-        log.debug("resolving {} -> {}", requestHost, appId);
+        log.debug("Resolved {} -> {}", requestHost, appId);
         return Optional.of(appId);
     }
 

--- a/src/main/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilter.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilter.java
@@ -6,7 +6,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.autoconfigure.security.reactive.EndpointRequest;
-import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -38,7 +37,7 @@ public class ContentGridAppRequestWebFilter implements WebFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         return this.requestRouter.route(exchange)
-                .switchIfEmpty(Mono.defer(() -> this.logServiceInstanceNotFound(exchange)))
+                .switchIfEmpty(Mono.defer(() -> this.logServiceInstanceNotFound(exchange).then(Mono.empty())))
                 .doOnNext(service ->
                 {
                     var appId = serviceMetadata.getApplicationId(service);
@@ -56,7 +55,7 @@ public class ContentGridAppRequestWebFilter implements WebFilter {
                 .then(chain.filter(exchange));
     }
 
-    private Mono<ServiceInstance> logServiceInstanceNotFound(ServerWebExchange exchange) {
+    private Mono<?> logServiceInstanceNotFound(ServerWebExchange exchange) {
         // EndpointRequest requires application context
         // but application context is always null in a MockServerWebExchange (from tests)
         if (exchange.getApplicationContext() == null) {

--- a/src/main/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilter.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/web/ContentGridAppRequestWebFilter.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.autoconfigure.security.reactive.EndpointRequest;
+import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -37,19 +38,7 @@ public class ContentGridAppRequestWebFilter implements WebFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         return this.requestRouter.route(exchange)
-
-                // check if this is a request to a gateway actuator
-                .switchIfEmpty(EndpointRequest.toAnyEndpoint().matches(exchange)
-                        .doOnNext(result -> {
-                            // if it is not an actuator request, we might want to log this
-                            if (!result.isMatch()) {
-                                // potentially return HTTP 503 early here in the future ?
-                                var method = exchange.getRequest().getMethod();
-                                var uri = exchange.getRequest().getURI();
-                                log.warn("No route found: {} {}", method, uri);
-                            }
-                        })
-                        .flatMap(result -> Mono.empty()))
+                .switchIfEmpty(Mono.defer(() -> this.logServiceInstanceNotFound(exchange)))
                 .doOnNext(service ->
                 {
                     var appId = serviceMetadata.getApplicationId(service);
@@ -65,6 +54,27 @@ public class ContentGridAppRequestWebFilter implements WebFilter {
                     deployId.ifPresent(value -> attributes.put(CONTENTGRID_DEPLOY_ID_ATTR, value));
                 })
                 .then(chain.filter(exchange));
+    }
+
+    private Mono<ServiceInstance> logServiceInstanceNotFound(ServerWebExchange exchange) {
+        // EndpointRequest requires application context
+        // but application context is always null in a MockServerWebExchange (from tests)
+        if (exchange.getApplicationContext() == null) {
+            return Mono.empty();
+        }
+
+        return EndpointRequest.toAnyEndpoint().matches(exchange)
+                .doOnNext(result -> {
+                    // if it is not an actuator request, we want to log this
+                    if (!result.isMatch()) {
+                        var method = exchange.getRequest().getMethod();
+                        var uri = exchange.getRequest().getURI();
+
+                        log.warn("No service found for {} {}", method, uri);
+                        // return HTTP 503 early here in the future ?
+                    }
+                })
+                .flatMap(result -> Mono.empty());
     }
 
 }


### PR DESCRIPTION
This PR cleans up some logging and prevents spamming the logs when k8s performs health checks with `GET /actuator/health`

```
-- GET 100.64.4.239 no route found
-- GET 100.64.4.239 no route found
-- GET 100.64.4.239 no route found
```

1. If the `ServerWebExchange` matches an actuator endpoint, do nothing
2. If it does not match an actuator endpoint, log with `WARN` level:

```
No route found: GET http://localhost:8080/foobar
```