### PR TITLE
Fixes NPE in DynamicReactiveClientRegistrationRepository bean config when receiving a CLEAR event

### DIFF
--- a/src/main/java/com/contentgrid/gateway/runtime/config/ApplicationConfigurationFragment.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/config/ApplicationConfigurationFragment.java
@@ -38,6 +38,10 @@ public class ApplicationConfigurationFragment implements ApplicationConfiguratio
         return this.properties.entrySet().stream();
     }
 
+    public static ApplicationConfiguration from(ApplicationId appId, Map<String, String> properties) {
+        return new ApplicationConfigurationFragment(UUID.randomUUID().toString(), appId, Map.copyOf(properties));
+    }
+
     public static ApplicationConfiguration fromProperties(Map<String, String> properties) {
         return new ApplicationConfigurationFragment(UUID.randomUUID().toString(), ApplicationId.random(), Map.copyOf(properties));
     }

--- a/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
@@ -10,7 +10,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
-public class OAuth2ClientApplicationConfigurationMapper {
+public class OAuth2ClientApplicationConfigurationMapper implements ReactiveClientRegistrationResolver {
 
     @NonNull
     private final ReactiveClientRegistrationIdResolver clientRegistrationIdResolver;
@@ -18,7 +18,8 @@ public class OAuth2ClientApplicationConfigurationMapper {
     public static final List<String> DEFAULT_SCOPES = List.of("openid", "profile", "email");
 
 
-    public Mono<ClientRegistration> getClientRegistration(@NonNull ApplicationConfiguration applicationConfiguration) {
+    @Override
+    public Mono<ClientRegistration> buildClientRegistration(@NonNull ApplicationConfiguration applicationConfiguration) {
 
         return this.clientRegistrationIdResolver.resolveRegistrationId(applicationConfiguration.getApplicationId())
                 .map(clientRegistrationId -> ClientRegistrations

--- a/src/main/java/com/contentgrid/gateway/security/oidc/OidcClientConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/OidcClientConfiguration.java
@@ -1,5 +1,6 @@
 package com.contentgrid.gateway.security.oidc;
 
+import com.contentgrid.gateway.collections.ObservableMap.UpdateType;
 import com.contentgrid.gateway.runtime.config.ApplicationConfigurationRepository;
 import com.contentgrid.gateway.runtime.routing.ApplicationIdRequestResolver;
 import com.contentgrid.gateway.security.oidc.DynamicReactiveClientRegistrationRepository.ClientRegistrationEvent;
@@ -50,9 +51,11 @@ class OidcClientConfiguration {
         }
 
         @Bean
-        ReactiveClientRegistrationResolver oAuth2ClientApplicationConfigurationMapper(ReactiveClientRegistrationIdResolver registrationIdResolver) {
+        ReactiveClientRegistrationResolver oAuth2ClientApplicationConfigurationMapper(
+                ReactiveClientRegistrationIdResolver registrationIdResolver) {
             return new OAuth2ClientApplicationConfigurationMapper(registrationIdResolver);
         }
+
         @Bean
         ReactiveClientRegistrationRepository clientRegistrationRepository(
                 ReactiveClientRegistrationIdResolver registrationIdResolver,
@@ -62,12 +65,20 @@ class OidcClientConfiguration {
 
             return new DynamicReactiveClientRegistrationRepository(applicationConfigurationRepository
                     .observe()
-                    .flatMap(update -> registrationIdResolver.resolveRegistrationId(update.getKey())
-                            .map(registrationId -> switch (update.getType()) {
-                                case PUT -> ClientRegistrationEvent.put(registrationId, clientRegistrationResolver.buildClientRegistration(update.getValue()));
-                                case REMOVE -> ClientRegistrationEvent.delete(registrationId);
-                                case CLEAR -> ClientRegistrationEvent.clear();
-                            }))
+                    .flatMap(update -> {
+                        if (update.getType().equals(UpdateType.CLEAR)) {
+                            return Mono.just(ClientRegistrationEvent.clear());
+                        }
+
+                        return registrationIdResolver.resolveRegistrationId(update.getKey()).map(registrationId -> {
+                            if (update.getType().equals(UpdateType.REMOVE)) {
+                                return ClientRegistrationEvent.delete(registrationId);
+                            }
+
+                            var client = clientRegistrationResolver.buildClientRegistration(update.getValue());
+                            return ClientRegistrationEvent.put(registrationId, client);
+                        });
+                    })
                     .doOnNext(event -> log.debug("ReactiveClientRegistrationRepository -> {}", event))
             );
         }

--- a/src/main/java/com/contentgrid/gateway/security/oidc/ReactiveClientRegistrationResolver.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/ReactiveClientRegistrationResolver.java
@@ -1,0 +1,11 @@
+package com.contentgrid.gateway.security.oidc;
+
+import com.contentgrid.gateway.runtime.config.ApplicationConfiguration;
+import lombok.NonNull;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import reactor.core.publisher.Mono;
+
+public interface ReactiveClientRegistrationResolver {
+
+    Mono<ClientRegistration> buildClientRegistration(@NonNull ApplicationConfiguration applicationConfiguration);
+}

--- a/src/test/java/com/contentgrid/gateway/security/oidc/OidcClientConfigurationTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/oidc/OidcClientConfigurationTest.java
@@ -1,0 +1,82 @@
+package com.contentgrid.gateway.security.oidc;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+
+import com.contentgrid.gateway.runtime.application.ApplicationId;
+import com.contentgrid.gateway.runtime.config.ApplicationConfiguration.Keys;
+import com.contentgrid.gateway.runtime.config.ApplicationConfigurationFragment;
+import com.contentgrid.gateway.runtime.config.ComposableApplicationConfigurationRepository;
+import com.contentgrid.gateway.test.assertj.MonoAssert;
+import java.util.Map;
+import lombok.NonNull;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+class OidcClientConfigurationTest {
+
+    @Nested
+    @SpringBootTest(properties = "contentgrid.gateway.runtime-platform.enabled=true")
+    class RuntimePlatformOAuth2ClientConfiguration {
+
+        @Autowired
+        ComposableApplicationConfigurationRepository appConfigRepository;
+
+        @Autowired
+        ReactiveClientRegistrationRepository clientRegistrationRepository;
+
+        @Autowired
+        ReactiveClientRegistrationIdResolver clientIdResolver;
+
+        @MockBean
+        ReactiveClientRegistrationResolver clientResolver;
+
+
+        @Test
+        void testClientRegistrationCycle() {
+            var appId = ApplicationId.random();
+            var clientId = clientIdResolver.resolveRegistrationId(appId);
+
+            // when asked to build a client-registration given app-config, return a stubbed client-registration
+            when(clientResolver.buildClientRegistration(argThat(config -> config.getApplicationId().equals(appId))))
+                    .thenReturn(clientId.map(OidcClientConfigurationTest::createClientRegistration));
+
+            // lookup client-registration by registration-id, expect empty result
+            var clientNotFound = clientId.flatMap(clientRegistrationRepository::findByRegistrationId);
+            MonoAssert.assertThat(clientNotFound).isEmptyMono();
+
+            // update the config-repo, subscribed client-registration-service should get reactor update-events
+            appConfigRepository.merge(ApplicationConfigurationFragment.from(appId, Map.of(
+                    Keys.ROUTING_DOMAINS, "my.domain.test"
+            )));
+
+            // now the config-repo has sent update-event to subscribers, client-registration-repo should return client
+            var clientFound = clientId.flatMap(clientRegistrationRepository::findByRegistrationId);
+            MonoAssert.assertThat(clientFound).hasValue();
+
+            // clear all configs, triggering a clear-event to the client-registration subscriber
+            appConfigRepository.clear();
+            var clientGone = clientId.flatMap(clientRegistrationRepository::findByRegistrationId);
+            MonoAssert.assertThat(clientGone).isEmptyMono();
+        }
+
+    }
+
+    @NonNull
+    private static ClientRegistration createClientRegistration(String registrationId) {
+        return ClientRegistration.withRegistrationId(registrationId)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .clientId("client-id")
+                .redirectUri("{baseUrl}/{action}/oauth2/code/{registrationId}")
+                .authorizationUri("https://auth.contentgrid.com/realms/name/protocol/openid-connect/auth")
+                .tokenUri("https://auth.contentgrid.com/realms/name/protocol/openid-connect/token")
+                .build();
+    }
+
+}


### PR DESCRIPTION
1. Introduces `ReactiveClientRegistrationResolver` as a bean to facilitate testing
2. Adds failing test with NPE
3. Fixes NPE