### PR TITLE
Use DefaultOpaInputProvider when runtime-platform is not enabled

### DIFF
--- a/src/main/java/com/contentgrid/gateway/GatewayApplication.java
+++ b/src/main/java/com/contentgrid/gateway/GatewayApplication.java
@@ -3,7 +3,7 @@ package com.contentgrid.gateway;
 import com.contentgrid.gateway.cors.CorsConfigurationResolver;
 import com.contentgrid.gateway.cors.CorsResolverProperties;
 import com.contentgrid.gateway.error.ProxyUpstreamUnavailableWebFilter;
-import com.contentgrid.gateway.security.opa.ContentgridOpaInputProvider;
+import com.contentgrid.gateway.runtime.authorization.RuntimeOpaInputProvider;
 import com.contentgrid.opa.client.OpaClient;
 import com.contentgrid.opa.client.rest.RestClientConfiguration.LogSpecification;
 import com.contentgrid.thunx.pdp.PolicyDecisionComponentImpl;
@@ -12,6 +12,7 @@ import com.contentgrid.thunx.pdp.opa.OpaInputProvider;
 import com.contentgrid.thunx.pdp.opa.OpaQueryProvider;
 import com.contentgrid.thunx.pdp.opa.OpenPolicyAgentPDPClient;
 import com.contentgrid.thunx.spring.gateway.filter.AbacGatewayFilterFactory;
+import com.contentgrid.thunx.spring.security.DefaultOpaInputProvider;
 import com.contentgrid.thunx.spring.security.ReactivePolicyAuthorizationManager;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -151,15 +152,23 @@ public class GatewayApplication {
         return request -> opaProperties.getQuery();
     }
 
+
+
     @Bean
-    OpaInputProvider<Authentication, ServerWebExchange> opaInputProvider() {
-        return new ContentgridOpaInputProvider();
+    @ConditionalOnProperty(value = "contentgrid.gateway.runtime-platform.enabled", havingValue = "false", matchIfMissing = true)
+    OpaInputProvider<Authentication, ServerWebExchange> deafultOpaInputProvider() {
+        return new DefaultOpaInputProvider();
     }
 
     @Bean
     @ConditionalOnBean(OpaClient.class)
     public PolicyDecisionPointClient<Authentication, ServerWebExchange> pdpClient(OpaClient opaClient, OpaQueryProvider<ServerWebExchange> opaQueryProvider, OpaInputProvider<Authentication, ServerWebExchange> inputProvider) {
         return new OpenPolicyAgentPDPClient<>(opaClient, opaQueryProvider, inputProvider);
+    }
+
+    @Bean
+    public AbacGatewayFilterFactory abacGatewayFilterFactory() {
+        return new AbacGatewayFilterFactory();
     }
 
     @Bean
@@ -254,10 +263,7 @@ public class GatewayApplication {
 
         return http.build();
     }
-    @Bean
-    public AbacGatewayFilterFactory abacGatewayFilterFactory() {
-        return new AbacGatewayFilterFactory();
-    }
+
     @Bean
     public GlobalFilter proxyUpstreamUnavailableWebFilter() {
         return new ProxyUpstreamUnavailableWebFilter();

--- a/src/main/java/com/contentgrid/gateway/GatewayApplication.java
+++ b/src/main/java/com/contentgrid/gateway/GatewayApplication.java
@@ -156,7 +156,7 @@ public class GatewayApplication {
 
     @Bean
     @ConditionalOnProperty(value = "contentgrid.gateway.runtime-platform.enabled", havingValue = "false", matchIfMissing = true)
-    OpaInputProvider<Authentication, ServerWebExchange> deafultOpaInputProvider() {
+    OpaInputProvider<Authentication, ServerWebExchange> defaultOpaInputProvider() {
         return new DefaultOpaInputProvider();
     }
 

--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
@@ -7,6 +7,8 @@ import com.contentgrid.gateway.runtime.actuate.ContentGridActuatorEndpoint;
 import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
 import com.contentgrid.gateway.runtime.application.ServiceCatalog;
 import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.authorization.RuntimeOpaInputProvider;
+import com.contentgrid.gateway.runtime.authorization.RuntimeOpaQueryProvider;
 import com.contentgrid.gateway.runtime.config.ApplicationConfigurationRepository;
 import com.contentgrid.gateway.runtime.config.ComposableApplicationConfigurationRepository;
 import com.contentgrid.gateway.runtime.config.kubernetes.Fabric8ConfigMapMapper;
@@ -27,6 +29,7 @@ import com.contentgrid.gateway.runtime.servicediscovery.ServiceDiscovery;
 import com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter;
 import com.contentgrid.gateway.runtime.web.ContentGridResponseHeadersWebFilter;
 import com.contentgrid.gateway.security.oidc.ReactiveClientRegistrationIdResolver;
+import com.contentgrid.thunx.pdp.opa.OpaInputProvider;
 import com.contentgrid.thunx.pdp.opa.OpaQueryProvider;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +47,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.server.ServerWebExchange;
@@ -137,6 +141,11 @@ public class RuntimeConfiguration {
     CorsConfigurationSource runtimeCorsConfigurationSource(ApplicationIdRequestResolver applicationIdResolver,
             ApplicationConfigurationRepository appConfigRepository) {
         return new RuntimeCorsConfigurationSource(applicationIdResolver, appConfigRepository);
+    }
+
+    @Bean
+    OpaInputProvider<Authentication, ServerWebExchange> opaInputProvider() {
+        return new RuntimeOpaInputProvider();
     }
 
     @Bean

--- a/src/main/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModel.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModel.java
@@ -1,4 +1,4 @@
-package com.contentgrid.gateway.security.opa;
+package com.contentgrid.gateway.runtime.authorization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;

--- a/src/main/java/com/contentgrid/gateway/runtime/authorization/RequestModel.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/authorization/RequestModel.java
@@ -1,4 +1,4 @@
-package com.contentgrid.gateway.security.opa;
+package com.contentgrid.gateway.runtime.authorization;
 
 import java.net.URI;
 import java.util.List;

--- a/src/main/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaInputProvider.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaInputProvider.java
@@ -1,11 +1,11 @@
-package com.contentgrid.gateway.security.opa;
+package com.contentgrid.gateway.runtime.authorization;
 
 import com.contentgrid.thunx.pdp.opa.OpaInputProvider;
 import java.util.Map;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.server.ServerWebExchange;
 
-public class ContentgridOpaInputProvider implements OpaInputProvider<Authentication, ServerWebExchange> {
+public class RuntimeOpaInputProvider implements OpaInputProvider<Authentication, ServerWebExchange> {
 
     @Override
     public Map<String, Object> createInput(Authentication authenticationContext, ServerWebExchange requestContext) {

--- a/src/main/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaQueryProvider.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaQueryProvider.java
@@ -1,4 +1,4 @@
-package com.contentgrid.gateway.runtime;
+package com.contentgrid.gateway.runtime.authorization;
 
 import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter.CONTENTGRID_DEPLOY_ID_ATTR;
 

--- a/src/test/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModelTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModelTest.java
@@ -1,4 +1,4 @@
-package com.contentgrid.gateway.security.opa;
+package com.contentgrid.gateway.runtime.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/contentgrid/gateway/runtime/authorization/RequestModelTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/authorization/RequestModelTest.java
@@ -1,4 +1,4 @@
-package com.contentgrid.gateway.security.opa;
+package com.contentgrid.gateway.runtime.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaQueryProviderTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/authorization/RuntimeOpaQueryProviderTest.java
@@ -1,14 +1,16 @@
-package com.contentgrid.gateway.runtime;
+package com.contentgrid.gateway.runtime.authorization;
 
-import static com.contentgrid.gateway.runtime.RuntimeOpaQueryProvider.NO_MATCH_QUERY;
+import static com.contentgrid.gateway.runtime.authorization.RuntimeOpaQueryProvider.NO_MATCH_QUERY;
 import static com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter.CONTENTGRID_DEPLOY_ID_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.contentgrid.gateway.runtime.ServiceInstanceStubs;
 import com.contentgrid.gateway.runtime.application.ApplicationId;
 import com.contentgrid.gateway.runtime.application.ContentGridDeploymentMetadata;
 import com.contentgrid.gateway.runtime.application.DeploymentId;
 import com.contentgrid.gateway.runtime.application.ServiceCatalog;
 import com.contentgrid.gateway.runtime.application.SimpleContentGridDeploymentMetadata;
+import com.contentgrid.gateway.runtime.authorization.RuntimeOpaQueryProvider;
 import java.util.Optional;
 import lombok.NonNull;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Replaces https://github.com/xenit-eu/contentgrid-gateway/pull/207