### PR TITLE
Fix passing through of ABAC context to upstream service

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	implementation platform('com.contentgrid.thunx:thunx-bom:0.10.0')
-	implementation 'com.contentgrid.thunx:thunx-spring-gateway'
-	implementation 'com.contentgrid.thunx:thunx-pdp-opa'
+	implementation 'com.contentgrid.thunx:thunx-gateway-spring-boot-starter'
 
 	implementation 'org.springframework.cloud:spring-cloud-kubernetes-fabric8-loadbalancer'
 

--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
@@ -16,6 +16,7 @@ import com.contentgrid.gateway.runtime.config.kubernetes.Fabric8SecretMapper;
 import com.contentgrid.gateway.runtime.config.kubernetes.KubernetesResourceWatcherBinding;
 import com.contentgrid.gateway.runtime.cors.RuntimeCorsConfigurationSource;
 import com.contentgrid.gateway.runtime.routing.ApplicationIdRequestResolver;
+import com.contentgrid.gateway.runtime.routing.ApplicationIdRoutePredicateFactory;
 import com.contentgrid.gateway.runtime.routing.CachingApplicationIdRequestResolver;
 import com.contentgrid.gateway.runtime.routing.DefaultRuntimeRequestRouter;
 import com.contentgrid.gateway.runtime.routing.DynamicVirtualHostApplicationIdResolver;
@@ -39,6 +40,8 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointPr
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.cloud.CloudPlatform;
+import org.springframework.cloud.gateway.config.GatewayProperties;
+import org.springframework.cloud.gateway.config.conditional.ConditionalOnEnabledPredicate;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.GatewayFilterSpec;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
@@ -63,14 +66,9 @@ public class RuntimeConfiguration {
     }
 
     @Bean
-    RouteLocator runtimeAppRouteLocator(RouteLocatorBuilder builder, ApplicationIdRequestResolver appIdResolver) {
-        return builder.routes()
-                .route(r -> r
-                        .predicate(exchange -> appIdResolver.resolveApplicationId(exchange).isPresent())
-                        .filters(GatewayFilterSpec::preserveHostHeader)
-                        .uri("cg://ignored")
-                )
-                .build();
+    @ConditionalOnEnabledPredicate
+    ApplicationIdRoutePredicateFactory applicationIdRoutePredicateFactory(ApplicationIdRequestResolver applicationIdRequestResolver)  {
+        return new ApplicationIdRoutePredicateFactory(applicationIdRequestResolver);
     }
 
     @Bean

--- a/src/main/java/com/contentgrid/gateway/runtime/routing/ApplicationIdRoutePredicateFactory.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/routing/ApplicationIdRoutePredicateFactory.java
@@ -1,0 +1,43 @@
+package com.contentgrid.gateway.runtime.routing;
+
+import com.contentgrid.gateway.runtime.routing.ApplicationIdRoutePredicateFactory.Config;
+import java.util.function.Predicate;
+import org.springframework.cloud.gateway.handler.predicate.AbstractRoutePredicateFactory;
+import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
+import org.springframework.web.server.ServerWebExchange;
+
+public class ApplicationIdRoutePredicateFactory extends AbstractRoutePredicateFactory<Config> {
+
+    private final ApplicationIdRequestResolver applicationIdRequestResolver;
+
+    public ApplicationIdRoutePredicateFactory(ApplicationIdRequestResolver applicationIdRequestResolver) {
+        super(Config.class);
+        this.applicationIdRequestResolver = applicationIdRequestResolver;
+    }
+
+    @Override
+    public Predicate<ServerWebExchange> apply(Config config) {
+        return new GatewayPredicate() {
+            @Override
+            public boolean test(ServerWebExchange exchange) {
+                return applicationIdRequestResolver.resolveApplicationId(exchange).isPresent();
+            }
+
+            @Override
+            public Object getConfig() {
+                return config;
+            }
+
+            @Override
+            public String toString() {
+                return "ApplicationId";
+            }
+        };
+    }
+
+
+    public static class Config {
+
+
+    }
+}

--- a/src/main/resources/application-runtime.yml
+++ b/src/main/resources/application-runtime.yml
@@ -13,6 +13,10 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: app
+          uri: cg://ignored
+          predicates:
+            - ApplicationId=
         - id: root
           uri: https://ignored
           predicates:

--- a/src/main/resources/application-runtime.yml
+++ b/src/main/resources/application-runtime.yml
@@ -17,12 +17,6 @@ spring:
           uri: cg://ignored
           predicates:
             - ApplicationId=
-        - id: root
-          uri: https://ignored
-          predicates:
-            - Path=/
-          filters:
-            - RedirectTo=302, /me
 
 servicediscovery:
   namespace: default

--- a/src/test/java/com/contentgrid/gateway/KubernetesServiceDiscoveryIntegrationTest.java
+++ b/src/test/java/com/contentgrid/gateway/KubernetesServiceDiscoveryIntegrationTest.java
@@ -124,9 +124,7 @@ public class KubernetesServiceDiscoveryIntegrationTest {
             "spring.main.cloud-platform=kubernetes",
             "servicediscovery.namespace=default",
             "servicediscovery.enabled=true",
-
-            // https://github.com/spring-cloud/spring-cloud-gateway/issues/2909
-            "spring.cloud.gateway.default-filters=PreserveHostHeader"
+            "spring.profiles.active=runtime"
     })
     @AutoConfigureWebTestClient
     public class HappyPathTest {


### PR DESCRIPTION
- Use thunx autoconfiguration instead of manually defining the required beans
- Add tests for permission checks being obeyed
- Use routes configured in configuration instead of creating a custom RouteLocator
