### PR TITLE
Add x-abac-policy claim to internal issued JWT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
 	implementation platform('com.contentgrid.thunx:thunx-bom:0.10.0')
 	implementation 'com.contentgrid.thunx:thunx-gateway-spring-boot-starter'
+	implementation 'com.contentgrid.thunx:thunx-encoding-json'
 
 	implementation 'org.springframework.cloud:spring-cloud-kubernetes-fabric8-loadbalancer'
 

--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimeConfiguration.java
@@ -74,10 +74,11 @@ public class RuntimeConfiguration {
             ApplicationIdRequestResolver applicationIdRequestResolver,
             AbacGatewayFilterFactory abacGatewayFilterFactory,
             TokenRelayGatewayFilterFactory tokenRelayGatewayFilterFactory,
-            JwtSignerRegistry jwtSignerRegistry
+            JwtSignerRegistry jwtSignerRegistry,
+            RuntimeJwtClaimsResolver runtimeJwtClaimsResolver
     ) {
         GatewayFilter tokenFilter = jwtSignerRegistry.getSigner("apps")
-                .map(jwtSigner -> new SignedJwtIssuer(jwtSigner, new RuntimeJwtClaimsResolver()))
+                .map(jwtSigner -> new SignedJwtIssuer(jwtSigner, runtimeJwtClaimsResolver))
                 .<GatewayFilter>map(LocallyIssuedJwtGatewayFilter::new)
                 .orElseGet(tokenRelayGatewayFilterFactory::apply);
 
@@ -93,6 +94,11 @@ public class RuntimeConfiguration {
                         .uri("cg://ignored")
                 )
                 .build();
+    }
+
+    @Bean
+    RuntimeJwtClaimsResolver runtimeJwtClaimsResolver() {
+        return new RuntimeJwtClaimsResolver();
     }
 
     @Bean

--- a/src/main/java/com/contentgrid/gateway/runtime/jwt/issuer/RuntimeJwtClaimsResolver.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/jwt/issuer/RuntimeJwtClaimsResolver.java
@@ -4,6 +4,9 @@ import com.contentgrid.gateway.runtime.application.ApplicationId;
 import com.contentgrid.gateway.runtime.application.DeploymentId;
 import com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter;
 import com.contentgrid.gateway.security.jwt.issuer.JwtClaimsResolver;
+import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
+import com.contentgrid.thunx.predicates.model.ThunkExpression;
+import com.contentgrid.thunx.spring.security.ReactivePolicyAuthorizationManager;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +16,22 @@ import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
 public class RuntimeJwtClaimsResolver implements JwtClaimsResolver {
+    private static final ExpressionJsonConverter thunxExpressionConverter = new ExpressionJsonConverter();
+
     @Override
     public Mono<JWTClaimsSet> resolveAdditionalClaims(ServerWebExchange exchange, AuthenticationInformation authenticationInformation) {
         ApplicationId applicationId = exchange.getRequiredAttribute(ContentGridAppRequestWebFilter.CONTENTGRID_APP_ID_ATTR);
         DeploymentId deploymentId = exchange.getRequiredAttribute(ContentGridAppRequestWebFilter.CONTENTGRID_DEPLOY_ID_ATTR);
+        ThunkExpression<Boolean> abacPolicyPredicate = exchange.getAttribute(ReactivePolicyAuthorizationManager.ABAC_POLICY_PREDICATE_ATTR);
+
+        var jwtClaimsBuilder = new Builder();
+
+        if(abacPolicyPredicate != null) {
+            jwtClaimsBuilder.claim("x-abac-context", thunxExpressionConverter.encode(abacPolicyPredicate));
+        }
 
         return Mono.just(
-                new Builder()
+                jwtClaimsBuilder
                         .audience("contentgrid:app:"+applicationId+":"+deploymentId)
                         .claim(StandardClaimNames.NAME, authenticationInformation.getClaim(StandardClaimNames.NAME))
                         .claim("act", authenticationInformation.getClaim("act")) // RFC 8693

--- a/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtClaimsResolver.java
+++ b/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtClaimsResolver.java
@@ -2,14 +2,11 @@ package com.contentgrid.gateway.security.jwt.issuer;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import java.time.Instant;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Singular;
 import lombok.Value;
 import lombok.experimental.Delegate;
 import org.springframework.security.oauth2.core.ClaimAccessor;
-import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;

--- a/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtInternalIssuerConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtInternalIssuerConfiguration.java
@@ -12,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;

--- a/src/test/java/com/contentgrid/gateway/security/jwt/issuer/PropertiesBasedJwtSignerRegistryTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/jwt/issuer/PropertiesBasedJwtSignerRegistryTest.java
@@ -3,7 +3,6 @@ package com.contentgrid.gateway.security.jwt.issuer;
 import static com.contentgrid.gateway.security.jwt.issuer.CryptoTestUtils.createKeyPair;
 import static com.contentgrid.gateway.security.jwt.issuer.CryptoTestUtils.toPrivateKeyResource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.contentgrid.gateway.security.jwt.issuer.JwtInternalIssuerConfiguration.ContentgridGatewayJwtProperties;

--- a/src/test/java/com/contentgrid/gateway/security/jwt/issuer/SignedJwtIssuerTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/jwt/issuer/SignedJwtIssuerTest.java
@@ -3,7 +3,6 @@ package com.contentgrid.gateway.security.jwt.issuer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.within;
-import static org.assertj.core.api.InstanceOfAssertFactories.DURATION;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -17,7 +16,6 @@ import com.nimbusds.jwt.SignedJWT;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;


### PR DESCRIPTION
Having the ABAC policy part of the JWT used to communicate to the
application prevents bypassing ABAC policy by tampering with the
(unsigned) X-ABAC-Policy http header.

Tampering with the JWT is not possible because it is signed; omitting
the JWT is also not possible because the application requires a signed
JWT to access any resources at all.
