### PR TITLE
Add system to refresh spring-security Authentication

### DIFF
--- a/src/main/java/com/contentgrid/gateway/security/bearer/OAuth2ResourceServerConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/security/bearer/OAuth2ResourceServerConfiguration.java
@@ -2,6 +2,8 @@ package com.contentgrid.gateway.security.bearer;
 
 import com.contentgrid.gateway.runtime.routing.ApplicationIdRequestResolver;
 import com.contentgrid.gateway.security.oidc.ReactiveClientRegistrationIdResolver;
+import com.contentgrid.gateway.security.refresh.AuthenticationRefresher;
+import com.contentgrid.gateway.security.refresh.NoopAuthenticationRefresher;
 import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -11,6 +13,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity.OAuth2ResourceServerSpec;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.web.server.BearerTokenServerAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.server.authentication.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.server.DelegatingServerAuthenticationEntryPoint.DelegateEntry;
@@ -18,6 +21,10 @@ import org.springframework.security.web.server.authentication.AuthenticationConv
 
 @Configuration(proxyBeanMethods = false)
 public class OAuth2ResourceServerConfiguration {
+    @Bean
+    AuthenticationRefresher jwtAuthenticationRefresher() {
+        return new NoopAuthenticationRefresher(JwtAuthenticationToken.class);
+    }
 
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnProperty(value = "contentgrid.gateway.runtime-platform.enabled")

--- a/src/main/java/com/contentgrid/gateway/security/oidc/OidcIdTokenAuthenticationRefresher.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/OidcIdTokenAuthenticationRefresher.java
@@ -1,0 +1,111 @@
+package com.contentgrid.gateway.security.oidc;
+
+import com.contentgrid.gateway.security.refresh.AuthenticationRefresher;
+import java.time.Instant;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.oidc.authentication.ReactiveOidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class OidcIdTokenAuthenticationRefresher implements AuthenticationRefresher {
+    @NonNull
+    private final ServerOAuth2AuthorizedClientRepository authorizedClientRepository;
+
+    @NonNull
+    private final ReactiveOAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> accessTokenResponseClient;
+
+    @NonNull
+    @Setter
+    private ReactiveJwtDecoderFactory<ClientRegistration> jwtDecoderFactory = new ReactiveOidcIdTokenDecoderFactory();
+
+    @NonNull
+    private final ReactiveOAuth2UserService<OidcUserRequest, OidcUser> userService;
+
+    @NonNull
+    @Setter
+    private GrantedAuthoritiesMapper authoritiesMapper = authorities -> authorities;
+
+    @Override
+    public Mono<Authentication> refresh(Authentication authentication, ServerWebExchange exchange) {
+        if(authentication instanceof OAuth2AuthenticationToken oAuth2AuthenticationToken &&  oAuth2AuthenticationToken.getPrincipal() instanceof OidcUser oidcUser) {
+            var idTokenExpires = oidcUser.getIdToken().getExpiresAt();
+            if(idTokenExpires != null && idTokenExpires.isBefore(Instant.now())) {
+                return doRefresh(oAuth2AuthenticationToken, exchange).checkpoint("OidcIdTokenAuthenticationRefresher");
+            } else {
+                return Mono.just(authentication);
+            }
+        }
+        return Mono.empty();
+    }
+
+    private Mono<Authentication> doRefresh(OAuth2AuthenticationToken oAuth2AuthenticationToken,
+            ServerWebExchange exchange) {
+        // Load authorized client
+        return authorizedClientRepository.loadAuthorizedClient(oAuth2AuthenticationToken.getAuthorizedClientRegistrationId(), oAuth2AuthenticationToken, exchange)
+                .flatMap(authorizedClient -> {
+                    // perform a token refresh
+                     return accessTokenResponseClient.getTokenResponse(new OAuth2RefreshTokenGrantRequest(authorizedClient.getClientRegistration(), authorizedClient.getAccessToken(), authorizedClient.getRefreshToken()))
+                             .onErrorMap(OAuth2AuthorizationException.class, ex -> new OAuth2AuthenticationException(ex.getError(), ex))
+                             // store the refreshed client credentials
+                             .flatMap(accessTokenResponse -> authorizedClientRepository.saveAuthorizedClient(updateAuthorizedClient(authorizedClient, accessTokenResponse), oAuth2AuthenticationToken, exchange)
+                                     .thenReturn(accessTokenResponse)
+                             )
+                             // Create the new authentication from the token response
+                             .flatMap(accessTokenResponse -> createAuthenticationFromTokenResponse(authorizedClient.getClientRegistration(), accessTokenResponse));
+                });
+    }
+
+    private static OAuth2AuthorizedClient updateAuthorizedClient(OAuth2AuthorizedClient oldClient, OAuth2AccessTokenResponse oAuth2AccessTokenResponse) {
+        return new OAuth2AuthorizedClient(
+                oldClient.getClientRegistration(),
+                oldClient.getPrincipalName(),
+                oAuth2AccessTokenResponse.getAccessToken(),
+                oAuth2AccessTokenResponse.getRefreshToken()
+        );
+    }
+
+    // See also OidcAuthorizationCodeReactiveAuthenticationManager
+    private Mono<Authentication> createAuthenticationFromTokenResponse(ClientRegistration clientRegistration, OAuth2AccessTokenResponse accessTokenResponse) {
+        var accessToken = accessTokenResponse.getAccessToken();
+        return createOidcIdToken(clientRegistration, accessTokenResponse)
+                .map(idToken -> new OidcUserRequest(clientRegistration, accessToken, idToken, accessTokenResponse.getAdditionalParameters()))
+                .flatMap(this.userService::loadUser)
+                .map(oauth2User -> {
+                    var mappedAuthorities = authoritiesMapper.mapAuthorities(oauth2User.getAuthorities());
+                    return new OAuth2AuthenticationToken(oauth2User, mappedAuthorities, clientRegistration.getRegistrationId());
+                });
+    }
+
+    private Mono<OidcIdToken> createOidcIdToken(ClientRegistration clientRegistration, OAuth2AccessTokenResponse accessTokenResponse) {
+        var jwtDecoder = this.jwtDecoderFactory.createDecoder(clientRegistration);
+        var rawIdToken = (String) accessTokenResponse.getAdditionalParameters().get(OidcParameterNames.ID_TOKEN);
+        if(rawIdToken == null) {
+            var invalidIdTokenError = new OAuth2Error("invalid_id_token", "Missing required ID Token in Token Response for Client Registration: "+clientRegistration.getRegistrationId(), null);
+            return Mono.error(new OAuth2AuthenticationException(invalidIdTokenError, invalidIdTokenError.toString()));
+        }
+        return jwtDecoder.decode(rawIdToken)
+                .map((jwt) -> new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims()));
+
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefresher.java
+++ b/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefresher.java
@@ -1,0 +1,9 @@
+package com.contentgrid.gateway.security.refresh;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+public interface AuthenticationRefresher {
+    Mono<Authentication> refresh(Authentication authentication, ServerWebExchange exchange);
+}

--- a/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefresherAutoConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefresherAutoConfiguration.java
@@ -1,0 +1,27 @@
+package com.contentgrid.gateway.security.refresh;
+
+import java.util.List;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+@AutoConfiguration
+public class AuthenticationRefresherAutoConfiguration {
+    @Bean
+    @Primary
+    AuthenticationRefresher authenticationRefresher(List<AuthenticationRefresher> authenticationRefreshers) {
+        return new CompositeAuthenticationRefresher(authenticationRefreshers);
+    }
+
+    @Bean
+    AuthenticationRefresher usernamePasswordAuthenticationRefresher() {
+        return new NoopAuthenticationRefresher(UsernamePasswordAuthenticationToken.class);
+    }
+
+    @Bean
+    AuthenticationRefresher anonymousAuthenticationRefresher() {
+        return new NoopAuthenticationRefresher(AnonymousAuthenticationToken.class);
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefreshingServerSecurityContextRepository.java
+++ b/src/main/java/com/contentgrid/gateway/security/refresh/AuthenticationRefreshingServerSecurityContextRepository.java
@@ -1,0 +1,48 @@
+package com.contentgrid.gateway.security.refresh;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationRefreshingServerSecurityContextRepository implements ServerSecurityContextRepository {
+    @NonNull
+    private final ServerSecurityContextRepository delegate;
+
+    @NonNull
+    private final AuthenticationRefresher authenticationRefresher;
+
+    @Override
+    public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
+        return delegate.save(exchange, context);
+    }
+
+    @Override
+    public Mono<SecurityContext> load(ServerWebExchange exchange) {
+        return delegate.load(exchange)
+                .flatMap(context -> authenticationRefresher.refresh(context.getAuthentication(), exchange)
+                        .flatMap(authentication -> {
+                            // Update authentication and context when it has changed
+                            if(authentication != context.getAuthentication()) {
+                                context.setAuthentication(authentication);
+                                return save(exchange, context)
+                                        .thenReturn(context);
+                            }
+                            return Mono.just(context);
+                        })
+                        .onErrorResume(AuthenticationException.class, authError -> {
+                            log.debug("Authentication error during token refresh. Session was invalidated.", authError);
+                            context.setAuthentication(null);
+                            return save(exchange, context)
+                                    .thenReturn(context);
+                        })
+                );
+    }
+
+}

--- a/src/main/java/com/contentgrid/gateway/security/refresh/CompositeAuthenticationRefresher.java
+++ b/src/main/java/com/contentgrid/gateway/security/refresh/CompositeAuthenticationRefresher.java
@@ -1,0 +1,21 @@
+package com.contentgrid.gateway.security.refresh;
+
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class CompositeAuthenticationRefresher implements AuthenticationRefresher {
+    @NonNull
+    private final List<AuthenticationRefresher> refreshers;
+
+    @Override
+    public Mono<Authentication> refresh(Authentication authentication, ServerWebExchange exchange) {
+        return Flux.concat(refreshers.stream().map(refresher -> refresher.refresh(authentication, exchange)).toList())
+                .next();
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/refresh/NoopAuthenticationRefresher.java
+++ b/src/main/java/com/contentgrid/gateway/security/refresh/NoopAuthenticationRefresher.java
@@ -1,0 +1,22 @@
+package com.contentgrid.gateway.security.refresh;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class NoopAuthenticationRefresher implements AuthenticationRefresher{
+
+    @NonNull
+    private final Class<? extends Authentication> authenticationClass;
+
+    @Override
+    public Mono<Authentication> refresh(Authentication authentication, ServerWebExchange exchange) {
+        if(authenticationClass.isInstance(authentication)) {
+            return Mono.just(authentication);
+        }
+        return Mono.empty();
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.contentgrid.gateway.security.refresh.AuthenticationRefresherAutoConfiguration

--- a/src/test/java/com/contentgrid/gateway/security/oidc/OidcIdTokenAuthenticationRefresherTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/oidc/OidcIdTokenAuthenticationRefresherTest.java
@@ -1,0 +1,278 @@
+package com.contentgrid.gateway.security.oidc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.PlainJWT;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.MappedJwtClaimSetConverter;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoderFactory;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+class OidcIdTokenAuthenticationRefresherTest {
+
+    public static final Clock CLOCK = Clock.fixed(Instant.now(), ZoneOffset.UTC);
+
+
+    private static final String CLIENT_REGISTRATION_ID = "test-client-registration";
+    private static final ClientRegistration CLIENT_REGISTRATION = ClientRegistration.withRegistrationId(CLIENT_REGISTRATION_ID)
+            .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+            .build();
+
+    @Test
+    void keepsNonExpiredToken() {
+        var expiry = CLOCK.instant().plus(2, ChronoUnit.MINUTES);
+        var authorizedClient = new OAuth2AuthorizedClient(CLIENT_REGISTRATION, "test",
+                new OAuth2AccessToken(TokenType.BEARER, "access-token", CLOCK.instant().minus(1, ChronoUnit.SECONDS), expiry),
+                new OAuth2RefreshToken("refresh-token", CLOCK.instant().minus(1, ChronoUnit.SECONDS), expiry.plus(1, ChronoUnit.HOURS))
+        );
+        var authorizedClientRepo = new InMemoryServerOAuth2AuthorizedClientRepository(authorizedClient);
+        var refreshClient = Mockito.mock(ReactiveOAuth2AccessTokenResponseClient.class);
+        var userService = new NoopOidcReactiveOAuth2UserService();
+
+        var authenticationRefresher = new OidcIdTokenAuthenticationRefresher(
+                authorizedClientRepo,
+                refreshClient,
+                userService
+        );
+
+        authenticationRefresher.setJwtDecoderFactory(new PlainJwtReactiveJwtDecoderFactory());
+        authenticationRefresher.setClock(CLOCK);
+
+
+        var authentication = new OAuth2AuthenticationToken(
+                new DefaultOidcUser(List.of(), OidcIdToken.withTokenValue("XXX")
+                        .subject("test")
+                        .expiresAt(expiry)
+                        .build()),
+                List.of(),
+                CLIENT_REGISTRATION_ID
+        );
+
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+
+        assertThat(authenticationRefresher.refresh(authentication, exchange).block()).isInstanceOfSatisfying(OAuth2AuthenticationToken.class, newAuthentication -> {
+            assertThat(newAuthentication).isSameAs(authentication);
+            assertThat(newAuthentication.getPrincipal()).isInstanceOfSatisfying(OidcUser.class, oidcUser -> {
+                assertThat(oidcUser.getExpiresAt()).isCloseTo(expiry, within(1, ChronoUnit.SECONDS));
+            });
+        });
+
+        // check that existing access and refresh token are still being used
+        assertThat(authorizedClientRepo.loadAuthorizedClient(CLIENT_REGISTRATION_ID, authentication, exchange).block()).satisfies(authorizedClient1 -> {
+            assertThat(authorizedClient1.getAccessToken().getTokenValue()).isEqualTo("access-token");
+            assertThat(authorizedClient1.getRefreshToken().getTokenValue()).isEqualTo("refresh-token");
+        });
+    }
+
+    @Test
+    void refreshesExpiredToken() {
+        var expiry = CLOCK.instant().minus(1, ChronoUnit.MINUTES);
+        var authorizedClient = new OAuth2AuthorizedClient(CLIENT_REGISTRATION, "test",
+                new OAuth2AccessToken(TokenType.BEARER, "access-token", expiry.minus(1, ChronoUnit.SECONDS), expiry),
+                new OAuth2RefreshToken("refresh-token", expiry.minus(1, ChronoUnit.SECONDS), CLOCK.instant().plus(1, ChronoUnit.HOURS))
+        );
+        var authorizedClientRepo = new InMemoryServerOAuth2AuthorizedClientRepository(authorizedClient);
+        var refreshClient = Mockito.mock(ReactiveOAuth2AccessTokenResponseClient.class);
+        var userService = new NoopOidcReactiveOAuth2UserService();
+
+        var authenticationRefresher = new OidcIdTokenAuthenticationRefresher(
+                authorizedClientRepo,
+                refreshClient,
+                userService
+        );
+
+        authenticationRefresher.setJwtDecoderFactory(new PlainJwtReactiveJwtDecoderFactory());
+        authenticationRefresher.setClock(CLOCK);
+
+
+        var authentication = new OAuth2AuthenticationToken(
+                new DefaultOidcUser(List.of(), OidcIdToken.withTokenValue("XXX")
+                        .subject("test")
+                        .expiresAt(expiry)
+                        .build()),
+                List.of(),
+                CLIENT_REGISTRATION_ID
+        );
+
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+
+
+        Mockito.when(refreshClient.getTokenResponse(Mockito.any()))
+                .thenReturn(Mono.just(OAuth2AccessTokenResponse.withToken("access-token-2")
+                                .refreshToken("refresh-token-2")
+                                .expiresIn(360)
+                                .tokenType(TokenType.BEARER)
+                                .additionalParameters(Map.of(
+                                        "id_token", new PlainJWT(new JWTClaimsSet.Builder()
+                                                .subject("test")
+                                                .expirationTime(Date.from(CLOCK.instant().plus(5, ChronoUnit.MINUTES)))
+                                                .build()).serialize()
+                                ))
+                        .build()
+                ));
+
+        assertThat(authenticationRefresher.refresh(authentication, exchange).block()).isInstanceOfSatisfying(OAuth2AuthenticationToken.class, newAuthentication -> {
+            assertThat(newAuthentication.getPrincipal()).isInstanceOfSatisfying(OidcUser.class, oidcUser -> {
+                assertThat(oidcUser.getExpiresAt()).isCloseTo(
+                        CLOCK.instant().plus(5, ChronoUnit.MINUTES), within(1, ChronoUnit.SECONDS));
+            });
+        });
+
+        // check that new access and refresh token is stored
+        assertThat(authorizedClientRepo.loadAuthorizedClient(CLIENT_REGISTRATION_ID, authentication, exchange).block()).satisfies(authorizedClient1 -> {
+            assertThat(authorizedClient1.getAccessToken().getTokenValue()).isEqualTo("access-token-2");
+            assertThat(authorizedClient1.getRefreshToken().getTokenValue()).isEqualTo("refresh-token-2");
+        });
+    }
+
+    @Test
+    void handlesTokenRefreshFailure() {
+
+        var expiry = CLOCK.instant().minus(1, ChronoUnit.MINUTES);
+        var authorizedClient = new OAuth2AuthorizedClient(CLIENT_REGISTRATION, "test",
+                new OAuth2AccessToken(TokenType.BEARER, "access-token", expiry.minus(1, ChronoUnit.SECONDS), expiry),
+                new OAuth2RefreshToken("refresh-token", expiry.minus(1, ChronoUnit.SECONDS), CLOCK.instant().plus(1, ChronoUnit.HOURS))
+        );
+        var authorizedClientRepo = new InMemoryServerOAuth2AuthorizedClientRepository(authorizedClient);
+        var refreshClient = Mockito.mock(ReactiveOAuth2AccessTokenResponseClient.class);
+        var userService = new NoopOidcReactiveOAuth2UserService();
+
+        var authenticationRefresher = new OidcIdTokenAuthenticationRefresher(
+                authorizedClientRepo,
+                refreshClient,
+                userService
+        );
+
+        authenticationRefresher.setJwtDecoderFactory(new PlainJwtReactiveJwtDecoderFactory());
+        authenticationRefresher.setClock(CLOCK);
+
+
+        var authentication = new OAuth2AuthenticationToken(
+                new DefaultOidcUser(List.of(), OidcIdToken.withTokenValue("XXX")
+                        .subject("test")
+                        .expiresAt(expiry)
+                        .build()),
+                List.of(),
+                CLIENT_REGISTRATION_ID
+        );
+
+        var exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+
+
+        Mockito.when(refreshClient.getTokenResponse(Mockito.any()))
+                .thenReturn(Mono.error(new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_GRANT))));
+
+        assertThatThrownBy(() -> authenticationRefresher.refresh(authentication, exchange).blockOptional())
+                .isInstanceOf(OAuth2AuthenticationException.class);
+
+        // check that authorized client is removed
+        assertThat(authorizedClientRepo.loadAuthorizedClient(CLIENT_REGISTRATION_ID, authentication, exchange).blockOptional()).isEmpty();
+    }
+
+    private static class NoopOidcReactiveOAuth2UserService implements
+            ReactiveOAuth2UserService<OidcUserRequest, OidcUser> {
+
+        @Override
+        public Mono<OidcUser> loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+            return Mono.just(new DefaultOidcUser(null, userRequest.getIdToken()));
+        }
+    }
+
+    private static class PlainJwtReactiveJwtDecoderFactory implements ReactiveJwtDecoderFactory<ClientRegistration> {
+
+        @Override
+        public ReactiveJwtDecoder createDecoder(ClientRegistration context) {
+            return token -> {
+                try {
+                    var nimbusJwt = JWTParser.parse(token);
+                    var jwt = Jwt.withTokenValue(token)
+                            .headers(headers -> headers.putAll(nimbusJwt.getHeader().toJSONObject()))
+                            .claims(claims -> {
+                                try {
+                                    claims.putAll(
+                                            MappedJwtClaimSetConverter.withDefaults(Map.of())
+                                                    .convert(nimbusJwt.getJWTClaimsSet().getClaims())
+                                    );
+                                } catch (ParseException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                            .build();
+                    return Mono.just(jwt);
+                } catch (ParseException e) {
+                    throw new BadJwtException(e.getMessage(), e);
+                }
+            };
+        }
+    }
+
+    private static class InMemoryServerOAuth2AuthorizedClientRepository implements ServerOAuth2AuthorizedClientRepository{
+        private Map<String, OAuth2AuthorizedClient> clients = new HashMap<>();
+
+        public InMemoryServerOAuth2AuthorizedClientRepository(OAuth2AuthorizedClient ...authorizedClients) {
+            for (OAuth2AuthorizedClient authorizedClient : authorizedClients) {
+                saveAuthorizedClient(authorizedClient, null, null);
+            }
+        }
+
+        @Override
+        public <T extends OAuth2AuthorizedClient> Mono<T> loadAuthorizedClient(String clientRegistrationId,
+                Authentication principal, ServerWebExchange exchange) {
+            return Mono.justOrEmpty((T)clients.get(clientRegistrationId));
+        }
+
+        @Override
+        public Mono<Void> saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal,
+                ServerWebExchange exchange) {
+            clients.put(authorizedClient.getClientRegistration().getRegistrationId(), authorizedClient);
+            return Mono.just(authorizedClient).then();
+        }
+
+        @Override
+        public Mono<Void> removeAuthorizedClient(String clientRegistrationId, Authentication principal,
+                ServerWebExchange exchange) {
+            clients.remove(clientRegistrationId);
+            return Mono.just(clientRegistrationId).then();
+        }
+    }
+}


### PR DESCRIPTION
When we have an OIDC-based login, spring security keeps the original id token and claims in the security context.
A session can exist for a long time as long as it is actively being used. This is a problem, because:
- We want to base the gateway-issued JWT on the user token, including the expiry
- Permissions are based on claims in the spring-security Authentication. Changed claims should
  be reflected in the permissions, instead of whatever they were at the beginning being retained
- Revoking user sessions from the issuer happens by not allowing an already issued token to be refreshed anymore.
  If the token is never refreshed, it becomes impossible to revoke a session.
