### PR TITLE
Make it possible to bypass OPA authorization for runtime platform endpoints

### DIFF
--- a/src/main/java/com/contentgrid/gateway/runtime/RuntimePlatformProperties.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/RuntimePlatformProperties.java
@@ -2,7 +2,12 @@ package com.contentgrid.gateway.runtime;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.Accessors;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
@@ -13,9 +18,42 @@ public class RuntimePlatformProperties {
 
     private Map<String, EndpointConfiguration> endpoints = new HashMap<>();
 
+    public Stream<EndpointDefinition> endpoints() {
+        return endpoints.entrySet().stream().map(EndpointDefinition::new);
+    }
+
     @Data
     static class EndpointConfiguration {
         private String uri;
+        @NonNull
+        private AuthorizationType authorization = AuthorizationType.DEFAULT;
+    }
+
+    public enum AuthorizationType {
+        PUBLIC,
+        AUTHENTICATED,
+        DEFAULT
+    }
+
+    @Value
+    @Accessors(fluent = true)
+    @AllArgsConstructor
+    public static class EndpointDefinition {
+        private EndpointDefinition(Map.Entry<String, EndpointConfiguration> config) {
+            this(
+                    config.getKey(),
+                    config.getValue().getUri(),
+                    config.getValue().getAuthorization()
+            );
+        }
+
+        String endpointId;
+        String upstreamUri;
+        AuthorizationType authorizationType;
+
+        public String pathPattern() {
+            return "/.contentgrid/"+endpointId+"/**";
+        }
     }
 }
 


### PR DESCRIPTION
When performing a request to tokenmonger (/.contentgrid/authentication/** on an app domain), the gateway performs a query to OPA to authorize the request.

However, the ContentGrid application itself (which determines the OPA policy) does not know about the /.contentgrid/authentication endpoint (and it also does not handle that endpoint), so it does not have any rule permitting access.

It would be logical for the gateway to bypass authorization with OPA for endpoints that are configured on it:

1. Available gateway endpoints are dependent on the runtime platform setup.
   It is possible for some runtime platforms to not support certain endpoints, and it is also possible for more endpoints to be added later on (without having to regenerate and redeploy all applications)
   If an endpoint is not available, and the application defines access allowed in the policy, it will allow access to that URL in the ContentGrid app; which may be unexpected
2. ContentGrid applications have no knowledge about these endpoints being intercepted, so why would they have to set up a policy to handle that
3. The upstreams of gateway endpoints are in a better position to do authorization of the incoming requests. They can still query OPA themselves (and maybe with different parameters) to determine some authorization.
