### PR TITLE
ACC-1450: Add AuthenticationDetails GrantedAuthority to spring Authentication tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ dependencies {
 	testFixturesImplementation 'io.projectreactor:reactor-test'
 	testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	testFixturesImplementation 'org.springframework.security:spring-security-core'
+	testFixturesImplementation 'org.springframework.security:spring-security-oauth2-core'
 }
 
 test {

--- a/src/main/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModel.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModel.java
@@ -1,69 +1,123 @@
 package com.contentgrid.gateway.runtime.authorization;
 
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.ClaimAccessor;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
 
 @Value
 @Builder
 public class AuthenticationModel {
-    boolean authenticated;
 
-    Map<String, Object> principal;
+    AuthenticationKind kind;
 
-    String issuer;
-    @JsonProperty("authenticated_at")
-    Instant authenticatedAt;
-    String acr;
+    PrincipalModel principal;
+
+    ActorModel actor;
+
+    public enum AuthenticationKind {
+        @JsonProperty("anonymous")
+        ANONYMOUS,
+        @JsonProperty("user")
+        USER,
+        @JsonProperty("delegated")
+        DELEGATED,
+        @JsonProperty("system")
+        SYSTEM
+    }
+
+    @JsonProperty("authenticated")
+    public boolean isAuthenticated() {
+        return kind != AuthenticationKind.ANONYMOUS;
+    }
+
+    @Value
+    public static class ActorModel {
+
+        ActorKind kind;
+        String sub;
+    }
+
+    @Value
+    public static class PrincipalModel {
+
+        ActorKind kind;
+        @JsonAnyGetter
+        Map<String, Object> claims;
+
+    }
+
+    @RequiredArgsConstructor
+    public enum ActorKind {
+        @JsonProperty("user")
+        USER(ActorType.USER),
+        @JsonProperty("extension")
+        EXTENSION(ActorType.EXTENSION);
+        private final ActorType actorType;
+
+        public static ActorKind fromType(ActorType actorType) {
+            for (ActorKind actorKind : values()) {
+                if (actorKind.actorType == actorType) {
+                    return actorKind;
+                }
+            }
+            throw new IllegalArgumentException("ActorType '%s' is not mapped to any ActorKind.".formatted(actorType));
+        }
+    }
 
     public static AuthenticationModel from(Authentication authenticationContext) {
-        var claims = extractClaims(authenticationContext);
+        var maybeAuthenticationDetails = authenticationContext.getAuthorities()
+                .stream()
+                .filter(AuthenticationDetails.class::isInstance)
+                .map(AuthenticationDetails.class::cast)
+                .findFirst();
+        if (maybeAuthenticationDetails.isEmpty()) {
+            return AuthenticationModel.builder()
+                    .kind(AuthenticationKind.ANONYMOUS)
+                    .build();
+        }
+
+        var authenticationDetails = maybeAuthenticationDetails.get();
+
         return AuthenticationModel.builder()
-                .authenticated(!(authenticationContext instanceof AnonymousAuthenticationToken))
-                .principal(createPrincipal(claims))
-                .issuer(claims.getClaimAsString("iss"))
-                .authenticatedAt(claims.getClaimAsInstant("auth_time"))
-                .acr(claims.getClaimAsString("acr"))
+                .kind(createAuthenticationKind(authenticationDetails))
+                .principal(createPrincipal(authenticationDetails))
+                .actor(createActor(authenticationDetails))
                 .build();
     }
 
-    private static Map<String, Object> createPrincipal(ClaimAccessor claims) {
-        var principal = new HashMap<String, Object>();
-
-        for (String claimName : claims.getClaims().keySet()) {
-            switch (claimName) {
-                case "preferred_username" -> principal.put("username", claims.getClaimAsString(claimName));
-                case "email", "sub" -> principal.put(claimName, claims.getClaimAsString(claimName));
-            }
-            if(claimName.startsWith("contentgrid:")) {
-                principal.put(claimName, claims.getClaim(claimName));
-            }
+    private static AuthenticationKind createAuthenticationKind(AuthenticationDetails authenticationDetails) {
+        if (authenticationDetails.getActor() != null) {
+            return AuthenticationKind.DELEGATED;
         }
-
-        return principal;
+        return switch (authenticationDetails.getPrincipal().getType()) {
+            case USER -> AuthenticationKind.USER;
+            case EXTENSION -> AuthenticationKind.SYSTEM;
+        };
     }
 
-    private static ClaimAccessor extractClaims(Authentication authenticationContext) {
-        var principal = authenticationContext.getPrincipal();
-
-        if(principal instanceof ClaimAccessor claimAccessor) {
-            return claimAccessor;
-        }
-
-        // fallback to check authorities on the auth-object
-        var claims =  authenticationContext.getAuthorities().stream()
-                .filter(OAuth2UserAuthority.class::isInstance)
-                .map(OAuth2UserAuthority.class::cast)
-                .findAny()
-                .map(OAuth2UserAuthority::getAttributes)
-                .orElse(Map.of());
-        return () -> claims;
+    private static PrincipalModel createPrincipal(AuthenticationDetails authenticationDetails) {
+        return new PrincipalModel(
+                ActorKind.fromType(authenticationDetails.getPrincipal().getType()),
+                authenticationDetails.getPrincipal().getClaims().getClaims()
+        );
     }
+
+    private static ActorModel createActor(AuthenticationDetails authenticationDetails) {
+        var actor = authenticationDetails.getActor();
+        if (actor == null) {
+            return null;
+        }
+        return new ActorModel(
+                ActorKind.fromType(actor.getType()),
+                actor.getClaims().getClaimAsString(JwtClaimNames.SUB)
+        );
+    }
+
 }

--- a/src/main/java/com/contentgrid/gateway/runtime/security/authority/ClaimUtil.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/security/authority/ClaimUtil.java
@@ -1,0 +1,33 @@
+package com.contentgrid.gateway.runtime.security.authority;
+
+import java.util.Map.Entry;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+
+@UtilityClass
+public class ClaimUtil {
+
+    ClaimAccessor limitToKeys(ClaimAccessor original, Predicate<String> keyFilter) {
+        var filteredClaims = original.getClaims()
+                .entrySet()
+                .stream()
+                .filter(entry -> keyFilter.test(entry.getKey()))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        return () -> filteredClaims;
+    }
+
+    public ClaimAccessor userClaims(ClaimAccessor original) {
+        return limitToKeys(original, ClaimUtil::isUserClaim);
+    }
+
+    private boolean isUserClaim(String claimName) {
+        return switch (claimName) {
+            case JwtClaimNames.SUB, JwtClaimNames.ISS, StandardClaimNames.NAME, StandardClaimNames.EMAIL -> true;
+            default -> claimName.startsWith("contentgrid:");
+        };
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/runtime/security/bearer/RuntimePlatformOAuth2ResourceServerConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/security/bearer/RuntimePlatformOAuth2ResourceServerConfiguration.java
@@ -34,13 +34,6 @@ public class RuntimePlatformOAuth2ResourceServerConfiguration {
     }
 
     @Bean
-    UserGrantedAuthorityConverter runtimeUserGrantedAuthorityConverter(
-            Converter<ClaimAccessor, Actor> actorConverter
-    ) {
-        return new UserGrantedAuthorityConverter(actorConverter);
-    }
-
-    @Bean
     Customizer<OAuth2ResourceServerSpec> runtimeJwtAuthenticationManagerResolver(
             ApplicationIdRequestResolver applicationIdResolver,
             ReactiveClientRegistrationIdResolver registrationIdResolver,

--- a/src/main/java/com/contentgrid/gateway/runtime/security/bearer/RuntimePlatformOAuth2ResourceServerConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/security/bearer/RuntimePlatformOAuth2ResourceServerConfiguration.java
@@ -1,15 +1,24 @@
 package com.contentgrid.gateway.runtime.security.bearer;
 
 import com.contentgrid.gateway.runtime.routing.ApplicationIdRequestResolver;
+import com.contentgrid.gateway.runtime.security.authority.ClaimUtil;
+import com.contentgrid.gateway.security.authority.Actor;
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.ActorConverter;
+import com.contentgrid.gateway.security.authority.UserGrantedAuthorityConverter;
 import com.contentgrid.gateway.security.bearer.DynamicJwtAuthenticationManagerResolver;
 import com.contentgrid.gateway.security.oidc.ReactiveClientRegistrationIdResolver;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity.OAuth2ResourceServerSpec;
 import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtGrantedAuthoritiesConverterAdapter;
 import org.springframework.security.oauth2.server.resource.web.server.BearerTokenServerAuthenticationEntryPoint;
 import org.springframework.security.oauth2.server.resource.web.server.authentication.ServerBearerTokenAuthenticationConverter;
 import org.springframework.security.web.server.DelegatingServerAuthenticationEntryPoint.DelegateEntry;
@@ -20,15 +29,36 @@ import org.springframework.security.web.server.authentication.AuthenticationConv
 public class RuntimePlatformOAuth2ResourceServerConfiguration {
 
     @Bean
+    Converter<ClaimAccessor, Actor> runtimeUserActorConverter() {
+        return new ActorConverter(iss -> true, ActorType.USER, ClaimUtil::userClaims);
+    }
+
+    @Bean
+    UserGrantedAuthorityConverter runtimeUserGrantedAuthorityConverter(
+            Converter<ClaimAccessor, Actor> actorConverter
+    ) {
+        return new UserGrantedAuthorityConverter(actorConverter);
+    }
+
+    @Bean
     Customizer<OAuth2ResourceServerSpec> runtimeJwtAuthenticationManagerResolver(
             ApplicationIdRequestResolver applicationIdResolver,
             ReactiveClientRegistrationIdResolver registrationIdResolver,
-            ReactiveClientRegistrationRepository clientRegistrationRepository) {
+            ReactiveClientRegistrationRepository clientRegistrationRepository,
+            UserGrantedAuthorityConverter userGrantedAuthorityConverter
+    ) {
         return spec -> {
             var resolver = new DynamicJwtAuthenticationManagerResolver(
                     applicationIdResolver,
                     registrationIdResolver,
-                    clientRegistrationRepository);
+                    clientRegistrationRepository
+            );
+
+            resolver.setAuthenticationManagerConfigurer(authenticationManager -> {
+                var authenticationConverter = new ReactiveJwtAuthenticationConverter();
+                authenticationConverter.setJwtGrantedAuthoritiesConverter(new ReactiveJwtGrantedAuthoritiesConverterAdapter(userGrantedAuthorityConverter));
+                authenticationManager.setJwtAuthenticationConverter(authenticationConverter);
+            });
             spec.authenticationManagerResolver(resolver);
         };
 

--- a/src/main/java/com/contentgrid/gateway/runtime/security/jwt/issuer/RuntimeJwtClaimsResolver.java
+++ b/src/main/java/com/contentgrid/gateway/runtime/security/jwt/issuer/RuntimeJwtClaimsResolver.java
@@ -2,6 +2,7 @@ package com.contentgrid.gateway.runtime.security.jwt.issuer;
 
 import com.contentgrid.gateway.runtime.application.ApplicationId;
 import com.contentgrid.gateway.runtime.application.DeploymentId;
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
 import com.contentgrid.gateway.runtime.web.ContentGridAppRequestWebFilter;
 import com.contentgrid.gateway.security.jwt.issuer.JwtClaimsResolver;
 import com.contentgrid.thunx.encoding.json.ExpressionJsonConverter;
@@ -19,7 +20,7 @@ public class RuntimeJwtClaimsResolver implements JwtClaimsResolver {
     private static final ExpressionJsonConverter thunxExpressionConverter = new ExpressionJsonConverter();
 
     @Override
-    public Mono<JWTClaimsSet> resolveAdditionalClaims(ServerWebExchange exchange, AuthenticationInformation authenticationInformation) {
+    public Mono<JWTClaimsSet> resolveAdditionalClaims(ServerWebExchange exchange, AuthenticationDetails authenticationDetails) {
         ApplicationId applicationId = exchange.getRequiredAttribute(ContentGridAppRequestWebFilter.CONTENTGRID_APP_ID_ATTR);
         DeploymentId deploymentId = exchange.getRequiredAttribute(ContentGridAppRequestWebFilter.CONTENTGRID_DEPLOY_ID_ATTR);
         ThunkExpression<Boolean> abacPolicyPredicate = exchange.getAttribute(ReactivePolicyAuthorizationManager.ABAC_POLICY_PREDICATE_ATTR);
@@ -33,7 +34,7 @@ public class RuntimeJwtClaimsResolver implements JwtClaimsResolver {
         return Mono.just(
                 jwtClaimsBuilder
                         .audience("contentgrid:app:"+applicationId+":"+deploymentId)
-                        .claim(StandardClaimNames.NAME, authenticationInformation.getClaim(StandardClaimNames.NAME))
+                        .claim(StandardClaimNames.NAME, authenticationDetails.getPrincipal().getClaims().getClaimAsString(StandardClaimNames.NAME))
                         .build()
         );
     }

--- a/src/main/java/com/contentgrid/gateway/security/authority/AbstractAuthenticationDetailsGrantedAuthority.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/AbstractAuthenticationDetailsGrantedAuthority.java
@@ -1,0 +1,25 @@
+package com.contentgrid.gateway.security.authority;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+abstract class AbstractAuthenticationDetailsGrantedAuthority implements AuthenticationDetails, GrantedAuthority {
+
+    @NonNull
+    private final Actor principal;
+
+    protected AbstractAuthenticationDetailsGrantedAuthority(@NonNull Actor principal) {
+        if(principal.getParent() != null) {
+            throw new IllegalArgumentException("Principal actor can not have a parent");
+        }
+        this.principal = principal;
+    }
+
+    @Override
+    public String getAuthority() {
+        return "AUTHENTICATION_ATTRIBUTES";
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/Actor.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/Actor.java
@@ -1,0 +1,53 @@
+package com.contentgrid.gateway.security.authority;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.experimental.FieldNameConstants;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+
+@Value
+@FieldNameConstants(level= AccessLevel.PRIVATE)
+public class Actor implements Serializable {
+
+    @NonNull
+    ActorType type;
+    @NonNull
+    ClaimAccessor claims;
+    Actor parent;
+
+    public enum ActorType {
+        USER,
+        EXTENSION
+    }
+
+    // Because Actor is embedded in a GrantedAuthority.
+    // It needs to be Serializable, so it can be stored in a session
+    @Serial
+    private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
+        stream.writeObject(type);
+        stream.writeObject(claims.getClaims());
+        stream.writeObject(parent);
+    }
+
+    @Serial
+    @SneakyThrows({NoSuchFieldException.class, IllegalAccessException.class})
+    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+        var typeField = Actor.class.getDeclaredField(Fields.type);
+        var claimsField = Actor.class.getDeclaredField(Fields.claims);
+        var parentField = Actor.class.getDeclaredField(Fields.parent);
+
+        typeField.setAccessible(true);
+        claimsField.setAccessible(true);
+        parentField.setAccessible(true);
+
+        typeField.set(this, stream.readObject());
+        claimsField.set(this, stream.readObject());
+        parentField.set(this, stream.readObject());
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/ActorConverter.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/ActorConverter.java
@@ -1,0 +1,60 @@
+package com.contentgrid.gateway.security.authority;
+
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import java.util.function.Predicate;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ActorConverter implements Converter<ClaimAccessor, Actor> {
+
+    private final Predicate<String> issuerMatcher;
+    private final ActorType actorType;
+    private final Converter<ClaimAccessor, ClaimAccessor> claimAccessorConverter;
+
+    @Setter
+    private Converter<ClaimAccessor, Actor> parentActorConverter;
+
+    @Override
+    public Actor convert(ClaimAccessor claimAccessor) {
+        var issuer = claimAccessor.getClaimAsString(JwtClaimNames.ISS);
+        if (issuer == null) {
+            throw new IllegalArgumentException("The 'iss' claim is required for actors");
+        }
+        if (!issuerMatcher.test(issuer)) {
+            return null;
+        }
+        var parentActorClaims = claimAccessor.getClaimAsMap("act");
+        Actor parentActor;
+        if (parentActorClaims != null) {
+            /* The actor claim has a nested actor claim. A nested claim means a "parent" actor
+               The full incoming token looks like this; the incoming ClaimAccessor is the value of the top-level 'act' key
+                {
+                  [...]
+                  "act": {
+                    "iss": "https://extensions.sandbox.contentgrid.cloud/authentication/system",
+                    "sub": "auth-demo",
+                    "act": {
+                      "iss": "https://scheduled-jobs.sandbox.contentgrid.cloud/authentication/system",
+                      "sub": "other-thing"
+                    }
+                  }
+              }
+             */
+            parentActor = parentActorConverter.convert(() -> parentActorClaims);
+        } else {
+            parentActor = null;
+        }
+
+        return new Actor(
+                actorType,
+                claimAccessorConverter.convert(claimAccessor),
+                parentActor
+        );
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/AggregateActorConverter.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/AggregateActorConverter.java
@@ -1,0 +1,22 @@
+package com.contentgrid.gateway.security.authority;
+
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+
+@RequiredArgsConstructor
+public class AggregateActorConverter implements Converter<ClaimAccessor, Actor> {
+
+    private final List<? extends Converter<ClaimAccessor, Actor>> converters;
+
+    @Override
+    public Actor convert(ClaimAccessor source) {
+        return converters
+                .stream()
+                .flatMap(converter -> Stream.ofNullable(converter.convert(source)))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/AuthenticationDetails.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/AuthenticationDetails.java
@@ -1,0 +1,9 @@
+package com.contentgrid.gateway.security.authority;
+
+
+public interface AuthenticationDetails {
+
+    Actor getPrincipal();
+
+    Actor getActor();
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/DelegatedAuthenticationDetailsGrantedAuthority.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/DelegatedAuthenticationDetailsGrantedAuthority.java
@@ -1,0 +1,16 @@
+package com.contentgrid.gateway.security.authority;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+@Getter
+public class DelegatedAuthenticationDetailsGrantedAuthority extends
+        AbstractAuthenticationDetailsGrantedAuthority {
+
+    private final Actor actor;
+
+    public DelegatedAuthenticationDetailsGrantedAuthority(@NonNull Actor principal, @NonNull Actor actor) {
+        super(principal);
+        this.actor = actor;
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/PrincipalAuthenticationDetailsGrantedAuthority.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/PrincipalAuthenticationDetailsGrantedAuthority.java
@@ -1,0 +1,15 @@
+package com.contentgrid.gateway.security.authority;
+
+import lombok.NonNull;
+
+public class PrincipalAuthenticationDetailsGrantedAuthority extends AbstractAuthenticationDetailsGrantedAuthority {
+
+    public PrincipalAuthenticationDetailsGrantedAuthority(@NonNull Actor principal) {
+        super(principal);
+    }
+
+    @Override
+    public Actor getActor() {
+        return null;
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/authority/UserGrantedAuthorityConverter.java
+++ b/src/main/java/com/contentgrid/gateway/security/authority/UserGrantedAuthorityConverter.java
@@ -1,0 +1,40 @@
+package com.contentgrid.gateway.security.authority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+@RequiredArgsConstructor
+public class UserGrantedAuthorityConverter implements
+        Converter<Jwt, Collection<GrantedAuthority>>, GrantedAuthoritiesMapper {
+
+    private final Converter<ClaimAccessor, Actor> actorConverter;
+
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt source) {
+        return List.of(createFromClaimAccessor(source));
+    }
+
+    private GrantedAuthority createFromClaimAccessor(ClaimAccessor claimAccessor) {
+        return new PrincipalAuthenticationDetailsGrantedAuthority(actorConverter.convert(claimAccessor));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> mapAuthorities(Collection<? extends GrantedAuthority> authorities) {
+        return Stream.concat(
+                authorities.stream(),
+                authorities.stream()
+                        .filter(OidcUserAuthority.class::isInstance)
+                        .map(OidcUserAuthority.class::cast)
+                        .map(OidcUserAuthority::getIdToken)
+                        .map(this::createFromClaimAccessor)
+        ).toList();
+    }
+}

--- a/src/main/java/com/contentgrid/gateway/security/bearer/OAuth2ResourceServerConfiguration.java
+++ b/src/main/java/com/contentgrid/gateway/security/bearer/OAuth2ResourceServerConfiguration.java
@@ -1,14 +1,27 @@
 package com.contentgrid.gateway.security.bearer;
 
+import com.contentgrid.gateway.security.authority.Actor;
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.ActorConverter;
+import com.contentgrid.gateway.security.authority.UserGrantedAuthorityConverter;
 import com.contentgrid.gateway.security.refresh.AuthenticationRefresher;
 import com.contentgrid.gateway.security.refresh.NoopAuthenticationRefresher;
+import java.util.Collection;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.web.server.ServerHttpSecurity.OAuth2ResourceServerSpec;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtGrantedAuthoritiesConverterAdapter;
+import reactor.core.publisher.Mono;
 
 @Configuration(proxyBeanMethods = false)
 public class OAuth2ResourceServerConfiguration {
@@ -18,12 +31,32 @@ public class OAuth2ResourceServerConfiguration {
     }
 
     @Bean
-    Customizer<OAuth2ResourceServerSpec> defaultJwtBearerAuth(ObjectProvider<ReactiveJwtDecoder> jwtDecoders) {
+    UserGrantedAuthorityConverter userGrantedAuthorityConverter(ObjectProvider<Converter<ClaimAccessor, Actor>> actorConverter) {
+        return new UserGrantedAuthorityConverter(actorConverter.getIfAvailable(this::defaultActorConverter));
+    }
+
+    @Bean
+    Customizer<OAuth2ResourceServerSpec> defaultJwtBearerAuth(
+            ObjectProvider<ReactiveJwtDecoder> jwtDecoders,
+            UserGrantedAuthorityConverter grantedAuthorityConverter
+    ) {
         var decoder = jwtDecoders.getIfAvailable();
         if (decoder == null) {
             return null;
         }
 
-        return spec -> spec.jwt(jwt -> jwt.jwtDecoder(decoder));
+        return spec -> spec.jwt(jwt -> jwt.jwtDecoder(decoder)
+                .jwtAuthenticationConverter(createAuthenticationConverter(grantedAuthorityConverter))
+        );
+    }
+
+    private static Converter<Jwt, ? extends Mono<? extends AbstractAuthenticationToken>> createAuthenticationConverter(Converter<Jwt, Collection<GrantedAuthority>> authorityConverter) {
+        var authenticationConverter = new ReactiveJwtAuthenticationConverter();
+        authenticationConverter.setJwtGrantedAuthoritiesConverter(new ReactiveJwtGrantedAuthoritiesConverterAdapter(authorityConverter));
+        return authenticationConverter;
+    }
+
+    private Converter<ClaimAccessor, Actor> defaultActorConverter() {
+        return new ActorConverter(iss -> true, ActorType.USER, ca -> ca);
     }
 }

--- a/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtClaimsResolver.java
+++ b/src/main/java/com/contentgrid/gateway/security/jwt/issuer/JwtClaimsResolver.java
@@ -1,39 +1,15 @@
 package com.contentgrid.gateway.security.jwt.issuer;
 
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
 import com.nimbusds.jwt.JWTClaimsSet;
-import java.time.Instant;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Value;
-import lombok.experimental.Delegate;
-import org.springframework.security.oauth2.core.ClaimAccessor;
-import org.springframework.security.oauth2.jwt.JwtClaimNames;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 public interface JwtClaimsResolver {
-    Mono<JWTClaimsSet> resolveAdditionalClaims(ServerWebExchange exchange, AuthenticationInformation authenticationInformation);
+    Mono<JWTClaimsSet> resolveAdditionalClaims(ServerWebExchange exchange, AuthenticationDetails authenticationDetails);
 
     static JwtClaimsResolver empty() {
-        return (exchange, authenticationInformation) -> Mono.just(new JWTClaimsSet.Builder().build());
+        return (exchange, authenticationDetails) -> Mono.just(new JWTClaimsSet.Builder().build());
     }
 
-    @Value
-    @Builder(access = AccessLevel.PRIVATE)
-    class AuthenticationInformation {
-        String issuer;
-        String subject;
-        Instant expiration;
-        @Delegate
-        ClaimAccessor claimAccessor;
-
-        static AuthenticationInformation fromClaims(ClaimAccessor claimAccessor) {
-            return AuthenticationInformation.builder()
-                    .issuer(claimAccessor.getClaimAsString(JwtClaimNames.ISS))
-                    .subject(claimAccessor.getClaimAsString(JwtClaimNames.SUB))
-                    .expiration(claimAccessor.getClaimAsInstant(JwtClaimNames.EXP))
-                    .claimAccessor(claimAccessor)
-                    .build();
-        }
-    }
 }

--- a/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
@@ -4,7 +4,6 @@ import com.contentgrid.gateway.runtime.config.ApplicationConfiguration;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.UtilityClass;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import reactor.core.publisher.Mono;

--- a/src/test/java/com/contentgrid/gateway/BootstrapUsersTest.java
+++ b/src/test/java/com/contentgrid/gateway/BootstrapUsersTest.java
@@ -4,12 +4,12 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.oneOf;
 
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,9 +37,6 @@ public class BootstrapUsersTest {
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
     }
 
-    @Autowired
-    private UserInfoController userInfoController;
-
     @Test
     public void testLogin() {
 
@@ -58,13 +55,23 @@ public class BootstrapUsersTest {
     @WithUserDetails("bob")
     public void testAuthorities() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        var result = userInfoController.userInfo(authentication);
-        assertThat(result).extractingByKey("employers", InstanceOfAssertFactories.LIST)
-                .containsExactlyInAnyOrder("BE0999999999", "BE0123456789");
-        assertThat(result).extractingByKey("customers", InstanceOfAssertFactories.LIST)
-                .containsExactlyInAnyOrder("BE9988776655", "BE5544332211", "BE0987654321");
-        assertThat(result).extractingByKey("singlevalue", InstanceOfAssertFactories.STRING)
-                .isEqualTo("BE1234567890");
+
+        var maybeAuthenticationDetails = authentication.getAuthorities()
+                .stream()
+                .filter(AuthenticationDetails.class::isInstance)
+                .map(AuthenticationDetails.class::cast)
+                .findFirst();
+
+        assertThat(maybeAuthenticationDetails).hasValueSatisfying(authenticationDetails -> {
+            assertThat(authenticationDetails.getPrincipal().getType()).isEqualTo(ActorType.USER);
+            assertThat(authenticationDetails.getPrincipal().getClaims().getClaimAsStringList("employers"))
+                    .containsExactlyInAnyOrder("BE0999999999", "BE0123456789");
+            assertThat(authenticationDetails.getPrincipal().getClaims().getClaimAsStringList("customers"))
+                    .containsExactlyInAnyOrder("BE9988776655", "BE5544332211", "BE0987654321");
+            assertThat(authenticationDetails.getPrincipal().getClaims().getClaimAsString("singlevalue"))
+                    .isEqualTo("BE1234567890");
+            assertThat(authenticationDetails.getActor()).isNull();
+        });
     }
 
 }

--- a/src/test/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModelTest.java
+++ b/src/test/java/com/contentgrid/gateway/runtime/authorization/AuthenticationModelTest.java
@@ -2,90 +2,125 @@ package com.contentgrid.gateway.runtime.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.contentgrid.gateway.runtime.authorization.AuthenticationModel.ActorKind;
+import com.contentgrid.gateway.runtime.authorization.AuthenticationModel.AuthenticationKind;
+import com.contentgrid.gateway.runtime.security.authority.ClaimUtil;
+import com.contentgrid.gateway.security.authority.UserGrantedAuthorityConverter;
+import com.contentgrid.gateway.security.authority.Actor;
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.ActorConverter;
+import com.contentgrid.gateway.security.authority.DelegatedAuthenticationDetailsGrantedAuthority;
+import com.contentgrid.gateway.security.authority.PrincipalAuthenticationDetailsGrantedAuthority;
 import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.ClaimAccessor;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.JoseHeaderNames;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 class AuthenticationModelTest {
+
+    private static final String USER_ISSUER = "https://authentication.invalid/realms/my-user-realm";
+    private static final String EXTENSION_SYSTEM_ISSUER = "https://extensions.invalid/authentication/system";
+    private static final Converter<ClaimAccessor, Actor> ACTOR_CONVERTER = new ActorConverter(iss -> true,
+            ActorType.USER, ClaimUtil::userClaims);
 
     @Test
     void fromOidcUser() {
         var instant = Instant.now();
 
         var idToken = OidcIdToken.withTokenValue("dummy")
+                .issuer(USER_ISSUER)
                 .subject("04c2cbec-faad-4dc8-ba6f-edb3d5b902e9")
-                .claim("preferred_username", "alice")
+                .claim(StandardClaimNames.EMAIL, "alice@wonderland.example")
+                .claim(StandardClaimNames.PREFERRED_USERNAME, "alice")
+                .claim("contentgrid:custom", List.of("blue", "green"))
                 .issuedAt(instant)
                 .expiresAt(instant.plus(5, ChronoUnit.MINUTES))
                 .authTime(instant)
                 // This is actually how we receive the issuer, as an URI
-                .claim(IdTokenClaimNames.ISS, URI.create("https://auth.contentgrid.com/auth/realms/my-org"))
+                .claim(IdTokenClaimNames.ISS, URI.create(USER_ISSUER))
                 .authorizedParty("contentgrid-gateway")
                 .build();
-        var userInfo = new OidcUserInfo(Map.of(
-                "contentgrid:custom", List.of("blue", "green"),
-                "email_verified", false
-        ));
+        var userInfo = new OidcUserInfo(idToken.getClaims());
         var userRole = new OidcUserAuthority(idToken, userInfo);
         var oidcUser = new DefaultOidcUser(Set.of(userRole), idToken, userInfo, "preferred_username");
 
-        var auth = new TestingAuthenticationToken(oidcUser, null, AuthorityUtils.NO_AUTHORITIES);
+        var converter = new UserGrantedAuthorityConverter(ACTOR_CONVERTER);
+
+        var auth = new TestingAuthenticationToken(oidcUser, null,
+                new ArrayList<>(converter.mapAuthorities(List.of(userRole))));
 
         var model = AuthenticationModel.from(auth);
 
-        assertThat(model.isAuthenticated()).isEqualTo(true);
+        assertThat(model.getKind()).isEqualTo(AuthenticationKind.USER);
 
-        assertThat(model.getPrincipal()).containsExactlyInAnyOrderEntriesOf(Map.of(
-                "username", "alice",
+        assertThat(model.getPrincipal().getKind()).isEqualTo(ActorKind.USER);
+        assertThat(model.getPrincipal().getClaims()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "iss", URI.create(USER_ISSUER),
                 "sub", idToken.getSubject(),
+                "email", "alice@wonderland.example",
                 "contentgrid:custom", List.of("blue", "green")
         ));
 
-        assertThat(model.getAuthenticatedAt()).isEqualTo(instant);
-        assertThat(model.getIssuer()).isEqualTo("https://auth.contentgrid.com/auth/realms/my-org");
+        assertThat(model.getActor()).isNull();
     }
 
     @Test
     void fromJwtAccessToken() {
         var instant = Instant.now();
 
-        var jwtToken = new ClaimAccessor() {
-
-            @Override
-            public Map<String, Object> getClaims() {
-                return Map.of("sub", "04c2cbec-faad-4dc8-ba6f-edb3d5b902e9",
+        var jwtToken = new Jwt(
+                "X",
+                Instant.now(),
+                Instant.MAX,
+                Map.of(
+                        JoseHeaderNames.TYP, "JWT",
+                        JoseHeaderNames.ALG, "none"
+                ),
+                Map.of(
+                        "iss", USER_ISSUER,
+                        "sub", "04c2cbec-faad-4dc8-ba6f-edb3d5b902e9",
                         "iat", instant,
                         "preferred_username", "alice",
+                        "name", "Alice",
+                        "email", "alice@wonderland.example",
                         "contentgrid:custom", List.of("blue", "green"),
                         "email_verified", false
-                );
+                )
+        );
 
-            }
-        };
-        var auth = new TestingAuthenticationToken(jwtToken, null, AuthorityUtils.NO_AUTHORITIES);
+        var converter = new UserGrantedAuthorityConverter(ACTOR_CONVERTER);
+
+        var auth = new TestingAuthenticationToken(jwtToken, null, new ArrayList<>(converter.convert(jwtToken)));
 
         var model = AuthenticationModel.from(auth);
 
         assertThat(model.isAuthenticated()).isEqualTo(true);
-        assertThat(model.getPrincipal()).containsAllEntriesOf(Map.of(
-                "username", "alice",
+        assertThat(model.getPrincipal().getKind()).isEqualTo(ActorKind.USER);
+        assertThat(model.getPrincipal().getClaims()).containsAllEntriesOf(Map.of(
+                "iss", USER_ISSUER,
+                "email", "alice@wonderland.example",
                 "sub", "04c2cbec-faad-4dc8-ba6f-edb3d5b902e9",
                 "contentgrid:custom", List.of("blue", "green")
         ));
+
+        assertThat(model.getActor()).isNull();
     }
 
     @Test
@@ -94,9 +129,71 @@ class AuthenticationModelTest {
         var model = AuthenticationModel.from(anonymousToken);
 
         assertThat(model.isAuthenticated()).isFalse();
-        assertThat(model.getAuthenticatedAt()).isNull();
-        assertThat(model.getIssuer()).isNull();
-        assertThat(model.getAcr()).isNull();
-        assertThat(model.getPrincipal()).isEmpty();
+        assertThat(model.getKind()).isEqualTo(AuthenticationKind.ANONYMOUS);
+        assertThat(model.getPrincipal()).isNull();
+        assertThat(model.getActor()).isNull();
+    }
+
+    @Test
+    void fromServiceAccountAccessToken() {
+        var model = AuthenticationModel.from(new TestingAuthenticationToken(null, null, List.of(
+                new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                        ActorType.EXTENSION,
+                        () -> Map.of(
+                                "iss", EXTENSION_SYSTEM_ISSUER,
+                                "sub", "extension123"
+                        ),
+                        null
+                ))
+        )));
+
+        assertThat(model.isAuthenticated()).isTrue();
+        assertThat(model.getKind()).isEqualTo(AuthenticationKind.SYSTEM);
+        assertThat(model.getPrincipal().getKind()).isEqualTo(ActorKind.EXTENSION);
+        assertThat(model.getPrincipal().getClaims()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "iss", EXTENSION_SYSTEM_ISSUER,
+                "sub", "extension123"
+        ));
+
+        assertThat(model.getActor()).isNull();
+    }
+
+    @Test
+    void fromDelegatedAccountAccessToken() {
+        var model = AuthenticationModel.from(new TestingAuthenticationToken(null, null, List.of(
+                new DelegatedAuthenticationDetailsGrantedAuthority(
+                        new Actor(
+                                ActorType.USER,
+                                () -> Map.of(
+                                        "iss", USER_ISSUER,
+                                        "sub", "user",
+                                        "contentgrid:claim1", "value1"
+                                ),
+                                null
+                        ),
+                        new Actor(
+                                ActorType.EXTENSION,
+                                () -> Map.of(
+                                        "iss", EXTENSION_SYSTEM_ISSUER,
+                                        "sub", "extension1"
+                                ),
+                                null
+                        )
+                )
+        )));
+
+        assertThat(model.isAuthenticated()).isTrue();
+        assertThat(model.getKind()).isEqualTo(AuthenticationKind.DELEGATED);
+
+        assertThat(model.getPrincipal().getKind()).isEqualTo(ActorKind.USER);
+        assertThat(model.getPrincipal().getClaims()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "iss", USER_ISSUER,
+                "sub", "user",
+                "contentgrid:claim1", "value1"
+        ));
+
+        assertThat(model.getActor().getKind()).isEqualTo(ActorKind.EXTENSION);
+        assertThat(model.getActor().getSub()).isEqualTo("extension1");
+
     }
 }

--- a/src/test/java/com/contentgrid/gateway/security/authority/ActorConverterTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/authority/ActorConverterTest.java
@@ -1,0 +1,98 @@
+package com.contentgrid.gateway.security.authority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.oauth2.jwt.JoseHeaderNames;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+
+class ActorConverterTest {
+    private static final String ISSUER = "https://issuer.invalid/r/xyz";
+
+    @Test
+    void convertsActorFromSimpleJwt() {
+        var converter = new ActorConverter(ISSUER::equals, ActorType.USER, ca -> ca);
+
+        var jwt = Jwt.withTokenValue("XYZ")
+                .header(JoseHeaderNames.ALG, "none")
+                .issuer(ISSUER)
+                .subject("user123")
+                .claim("my-claim", "vvvv")
+                .build();
+
+        var actor = converter.convert(jwt);
+
+        assertThat(actor.getType()).isEqualTo(ActorType.USER);
+        assertThat(actor.getClaims().getClaims()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "iss", ISSUER,
+                "sub", "user123",
+                "my-claim", "vvvv"
+        ));
+        assertThat(actor.getParent()).isNull();
+
+    }
+
+    @Test
+    void doesNotConvert_nonMatchingIssuer() {
+        var converter = new ActorConverter(String::isEmpty, ActorType.USER, ca -> ca);
+
+        var jwt = Jwt.withTokenValue("XYZ")
+                .header(JoseHeaderNames.ALG, "none")
+                .issuer(ISSUER)
+                .subject("user123")
+                .claim("my-claim", "vvvv")
+                .build();
+
+        var actor = converter.convert(jwt);
+        assertThat(actor).isNull();
+
+    }
+
+    @Test
+    void rejects_missingIssuer() {
+        var converter = new ActorConverter(String::isEmpty, ActorType.USER, ca -> ca);
+
+        var jwt = Jwt.withTokenValue("XYZ")
+                .header(JoseHeaderNames.ALG, "none")
+                .subject("user123")
+                .claim("my-claim", "vvvv")
+                .build();
+
+        assertThatThrownBy(() -> converter.convert(jwt))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void converts_withNestedActor() {
+        var converter = new ActorConverter(ISSUER::equals, ActorType.USER, ca -> ca);
+
+        var parentConverter = Mockito.mock(ActorConverter.class);
+
+        converter.setParentActorConverter(parentConverter);
+
+        var parentActor = new Actor(ActorType.EXTENSION, Map::of, null);
+        Mockito.when(parentConverter.convert(Mockito.any())).thenReturn(parentActor);
+
+        var jwt = Jwt.withTokenValue("XYZ")
+                .header(JoseHeaderNames.ALG, "none")
+                .issuer(ISSUER)
+                .subject("user123")
+                .claim("my-claim", "vvvv")
+                .claim("act", Map.of(
+                        "iss", ISSUER,
+                        "sub", "my-actor"
+                ))
+                .build();
+
+        assertThat(converter.convert(jwt)).satisfies(actor -> {
+            assertThat(actor.getType()).isEqualTo(ActorType.USER);
+            assertThat(actor.getClaims().getClaimAsString(JwtClaimNames.SUB)).isEqualTo("user123");
+            assertThat(actor.getParent()).isSameAs(parentActor);
+        });
+    }
+}

--- a/src/test/java/com/contentgrid/gateway/security/authority/AggregateActorConverterTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/authority/AggregateActorConverterTest.java
@@ -1,0 +1,49 @@
+package com.contentgrid.gateway.security.authority;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+
+@MockitoSettings
+class AggregateActorConverterTest {
+    @Mock
+    private Converter<ClaimAccessor, Actor> converter1;
+
+    @Mock
+    private Converter<ClaimAccessor, Actor> converter2;
+
+    @Test
+    void delegates_toFirst() {
+        var converter = new AggregateActorConverter(List.of(converter1, converter2));
+
+        var actor = new Actor(ActorType.USER, Map::of, null);
+
+        Mockito.when(converter1.convert(Mockito.any())).thenReturn(actor);
+        assertThat(converter.convert(Map::of)).isSameAs(actor);
+
+        Mockito.verifyNoInteractions(converter2);
+    }
+
+    @Test
+    void delegates_toFirstMatching() {
+        var converter = new AggregateActorConverter(List.of(converter1, converter2));
+
+        var actor = new Actor(ActorType.USER, Map::of, null);
+
+        Mockito.when(converter1.convert(Mockito.any())).thenReturn(null);
+        Mockito.when(converter2.convert(Mockito.any())).thenReturn(actor);
+
+        assertThat(converter.convert(Map::of)).isSameAs(actor);
+
+        Mockito.verify(converter1).convert(Mockito.any());
+    }
+
+}

--- a/src/test/java/com/contentgrid/gateway/security/jwt/issuer/SignedJwtIssuerTest.java
+++ b/src/test/java/com/contentgrid/gateway/security/jwt/issuer/SignedJwtIssuerTest.java
@@ -4,15 +4,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.within;
 
+import com.contentgrid.gateway.security.authority.Actor;
+import com.contentgrid.gateway.security.authority.Actor.ActorType;
+import com.contentgrid.gateway.security.authority.DelegatedAuthenticationDetailsGrantedAuthority;
+import com.contentgrid.gateway.security.authority.PrincipalAuthenticationDetailsGrantedAuthority;
 import com.contentgrid.gateway.test.security.jwt.SingleKeyJwtClaimsSigner;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.api.ThrowingConsumer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextImpl;
@@ -33,12 +39,13 @@ class SignedJwtIssuerTest {
     void creates_derived_jwt_for_authentication_token() {
         var issuer = new SignedJwtIssuer(CLAIMS_SIGNER, JwtClaimsResolver.empty());
         var exchange = createExchange(
-                new JwtAuthenticationToken(Jwt.withTokenValue("XXXX")
-                        .header("alg", "RS256")
-                        .claim("typ", "Bearer")
-                        .issuer("https://upstream-issuer.example")
-                        .subject("my-user")
-                        .build())
+                new TestingAuthenticationToken(null, null,
+                        List.of(new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                                ActorType.USER,
+                                () -> Map.of("iss", "https://upstream-issuer.example", "sub", "my-user"),
+                                null
+                        )))
+                )
         );
 
         assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {
@@ -51,18 +58,54 @@ class SignedJwtIssuerTest {
     }
 
     @Test
+    void creates_derived_jwt_for_delegation_token() {
+        var issuer = new SignedJwtIssuer(CLAIMS_SIGNER, JwtClaimsResolver.empty());
+        var exchange = createExchange(
+                new TestingAuthenticationToken(null, null,
+                        List.of(new DelegatedAuthenticationDetailsGrantedAuthority(new Actor(
+                                ActorType.USER,
+                                () -> Map.of(
+                                        "iss", "https://delegation-issuer.example",
+                                        "sub", "my-user"
+                                ),
+                                null
+                        ), new Actor(ActorType.EXTENSION, () -> Map.of(
+                                "iss", "https://extensions.invalid/authentication/system",
+                                "sub", "extension123"
+                        ), null)))
+                )
+        );
+
+        assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {
+            assertThat(token.getIssuer()).hasToString("https://delegation-issuer.example");
+            assertThat(token.getSubject()).isEqualTo("my-user");
+            assertThat(token.getIssuedAt()).isBeforeOrEqualTo(Instant.now());
+            assertThat(token.getClaimAsMap("act")).isEqualTo(Map.of(
+                    "iss", "https://extensions.invalid/authentication/system",
+                    "sub", "extension123"
+            ));
+            assertThat(token.getExpiresAt()).isBetween(Instant.now().plus(4, ChronoUnit.MINUTES), Instant.now().plus(5, ChronoUnit.MINUTES));
+            assertThat(token.getTokenValue()).satisfies(verifyJwtSignedBy(issuer));
+        });
+    }
+
+    @Test
     void creates_derived_jwt_for_oidc_user() {
         var issuer = new SignedJwtIssuer(CLAIMS_SIGNER, JwtClaimsResolver.empty());
         var oidcUser = new DefaultOidcUser(
                 List.of(),
                 OidcIdToken.withTokenValue("XXX")
-                        .claim("typ", "Bearer")
-                        .issuer("https://upstream-issuer.example")
                         .subject("my-user")
                         .build()
         );
 
-        var exchange = createExchange(new OAuth2AuthenticationToken(oidcUser, null, "my-client"));
+        var exchange = createExchange(new OAuth2AuthenticationToken(oidcUser,
+                List.of(new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                        ActorType.USER,
+                        () -> Map.of("iss", "https://upstream-issuer.example", "sub", "my-user"),
+                        null
+                )))
+, "my-client"));
 
         assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {
             assertThat(token.getIssuer()).hasToString("https://upstream-issuer.example");
@@ -77,7 +120,11 @@ class SignedJwtIssuerTest {
     void creates_derived_jwt_for_other_authentication() {
         var issuer = new SignedJwtIssuer(CLAIMS_SIGNER, JwtClaimsResolver.empty());
 
-        var exchange = createExchange(UsernamePasswordAuthenticationToken.authenticated("bob", null, List.of()));
+        var exchange = createExchange(UsernamePasswordAuthenticationToken.authenticated("bob", null, List.of(new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                ActorType.USER,
+                () -> Map.of("sub", "bob"),
+                null
+        )))));
 
         assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {
             assertThat(token.getIssuer()).isNull();
@@ -94,12 +141,15 @@ class SignedJwtIssuerTest {
 
         var exchange = createExchange(
                 new JwtAuthenticationToken(Jwt.withTokenValue("XXXX")
-                        .header("alg", "RS256")
-                        .claim("typ", "Bearer")
-                        .issuer("https://upstream-issuer.example")
-                        .subject("my-user")
+                        .header("alg", "none")
                         .expiresAt(Instant.now().plus(2, ChronoUnit.HOURS))
-                        .build())
+                        .build(),
+                        List.of(new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                                ActorType.USER,
+                                () -> Map.of("iss", "https://upstream-issuer.example", "sub", "my-user"),
+                                null
+                        )))
+                )
         );
         assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {
             assertThat(token.getExpiresAt()).isBetween(Instant.now().plus(4, ChronoUnit.MINUTES), Instant.now().plus(5, ChronoUnit.MINUTES));
@@ -114,11 +164,14 @@ class SignedJwtIssuerTest {
         var exchange = createExchange(
                 new JwtAuthenticationToken(Jwt.withTokenValue("XXXX")
                         .header("alg", "RS256")
-                        .claim("typ", "Bearer")
-                        .issuer("https://upstream-issuer.example")
-                        .subject("my-user")
                         .expiresAt(expiry)
-                        .build())
+                        .build(),
+                        List.of(new PrincipalAuthenticationDetailsGrantedAuthority(new Actor(
+                                ActorType.USER,
+                                () -> Map.of("iss", "https://upstream-issuer.example", "sub", "my-user"),
+                                null
+                        )))
+                )
         );
 
         assertThat(issuer.issueSubstitutionToken(exchange).block()).isInstanceOfSatisfying(Jwt.class, token -> {

--- a/src/testFixtures/java/com/contentgrid/gateway/test/controller/TestController.java
+++ b/src/testFixtures/java/com/contentgrid/gateway/test/controller/TestController.java
@@ -1,0 +1,25 @@
+package com.contentgrid.gateway.test.controller;
+
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+@RequestMapping("/_test")
+public class TestController {
+
+    @GetMapping("authenticationDetails")
+    AuthenticationDetails authenticationDetails(Authentication authentication) {
+        return authentication.getAuthorities()
+                .stream()
+                .filter(AuthenticationDetails.class::isInstance)
+                .map(AuthenticationDetails.class::cast)
+                .findFirst()
+                .orElse(null);
+    }
+
+}

--- a/src/testFixtures/java/com/contentgrid/gateway/test/security/ClaimAccessorMixin.java
+++ b/src/testFixtures/java/com/contentgrid/gateway/test/security/ClaimAccessorMixin.java
@@ -1,0 +1,19 @@
+package com.contentgrid.gateway.test.security;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.oauth2.core.ClaimAccessor;
+
+@JsonDeserialize(as = ClaimAccessorMixin.class)
+@Getter
+public class ClaimAccessorMixin implements ClaimAccessor {
+
+    @JsonCreator
+    public ClaimAccessorMixin(@JsonProperty("claims") Map<String, Object> claims) {
+        this.claims = claims;
+    }
+    private final Map<String, Object> claims;
+}

--- a/src/testFixtures/java/com/contentgrid/gateway/test/security/TestAuthenticationDetails.java
+++ b/src/testFixtures/java/com/contentgrid/gateway/test/security/TestAuthenticationDetails.java
@@ -1,0 +1,15 @@
+package com.contentgrid.gateway.test.security;
+
+import com.contentgrid.gateway.security.authority.Actor;
+import com.contentgrid.gateway.security.authority.AuthenticationDetails;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class TestAuthenticationDetails implements AuthenticationDetails {
+    Actor principal;
+    Actor actor;
+}


### PR DESCRIPTION
- **Add AuthenticationDetails as a GrantedAuthority to spring security Authentication**
- **Add AuthenticationDetails support for bootstrapped users**
- **Use AuthenticationDetails authority for defaultJwtBearerAuth**
- **Move SignedJwtIssuer to AuthenticationDetails instead of custom AuthenticationInformation**
- **Move OPA AuthenticationModel to use AuthenticationDetails instead of parsing claims directly**
- **Make OidcAuthenticationIntegrationTest check the AuthenticationDetails information using a custom test-only controller**
