### PR TITLE
Only enable contentgrid configuration discovery in kubernetes when in runtime-platform mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,9 +69,12 @@ dependencies {
 	implementation 'com.contentgrid.thunx:thunx-gateway-spring-boot-starter'
 	implementation 'com.contentgrid.thunx:thunx-encoding-json'
 
-	implementation platform('com.contentgrid.configuration:contentgrid-configuration-bom:0.1.1')
+	implementation platform('com.contentgrid.configuration:contentgrid-configuration-bom:0.1.2')
 	implementation 'com.contentgrid.configuration:contentgrid-configuration-contentgrid-apps'
-	runtimeOnly 'com.contentgrid.configuration:contentgrid-configuration-kubernetes-fabric8'
+	runtimeOnly('com.contentgrid.configuration:contentgrid-configuration-kubernetes-fabric8') {
+		// We need an older kubernetes client than provided by contentgrid configuration to be compatible with Spring Boot
+		exclude group: 'io.fabric8'
+	}
 	runtimeOnly 'com.contentgrid.configuration:contentgrid-configuration-properties-spring'
 	runtimeOnly 'com.contentgrid.configuration:contentgrid-configuration-autoconfigure'
 
@@ -109,7 +112,7 @@ dependencies {
 	testFixturesApi 'org.springframework:spring-webflux'
 	testFixturesApi 'org.springframework.security:spring-security-crypto'
 	testFixturesApi 'org.springframework.cloud:spring-cloud-commons'
-	testFixturesApi platform('com.contentgrid.configuration:contentgrid-configuration-bom:0.1.1')
+	testFixturesApi platform('com.contentgrid.configuration:contentgrid-configuration-bom:0.1.2')
 	testFixturesApi 'com.contentgrid.configuration:contentgrid-configuration-contentgrid-apps'
 
 	testFixturesImplementation platform('org.springframework.cloud:spring-cloud-dependencies:2023.0.3')

--- a/src/main/resources/application-runtime.yml
+++ b/src/main/resources/application-runtime.yml
@@ -14,6 +14,3 @@ spring:
 servicediscovery:
   namespace: default
   enabled: true
-
-contentgrid.configuration.discovery.kubernetes:
-  namespace: default

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,5 @@ contentgrid:
     user-info:
       enabled: false
       path: /me
+  configuration.discovery.kubernetes:
+    enabled: "${contentgrid.gateway.runtime-platform.enabled:false}"


### PR DESCRIPTION
When running for the management platform, we don't want to have kubernetes configuration discovery active,
as the gateway would not have permissions to connect to the kubernetes api anyways
