### PR TITLE
Do not cache client registration indefinitely

### DIFF
--- a/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
+++ b/src/main/java/com/contentgrid/gateway/security/oidc/OAuth2ClientApplicationConfigurationMapper.java
@@ -6,11 +6,13 @@ import com.contentgrid.configuration.applications.ApplicationId;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrations;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
+@Slf4j
 public class OAuth2ClientApplicationConfigurationMapper implements ReactiveClientRegistrationResolver {
 
     @NonNull
@@ -31,7 +33,8 @@ public class OAuth2ClientApplicationConfigurationMapper implements ReactiveClien
                                 .clientId(config.getClientId())
                                 .clientSecret(config.getClientSecret())
                                 .scope(DEFAULT_SCOPES)
-                                .build())
+                                .build()
+                        )
                 )
                 .flatMap(Mono::justOrEmpty);
     }


### PR DESCRIPTION
This is especially a problem if the client registration fails to resolve
due to a transient failure, where the failure gets cached forever.

However, it may also be an issue that a successful response is cached
forever, as the response from the openid-configuration endpoint can
change.

To avoid flooding an oidc server with requests, cache successful
responses for 10 minutes and failures for 1 minute.
