### PR TITLE
Avoid triggering service updates when the service has not changed

### DIFF
--- a/src/main/java/com/contentgrid/gateway/ServiceDiscoveryProperties.java
+++ b/src/main/java/com/contentgrid/gateway/ServiceDiscoveryProperties.java
@@ -1,5 +1,6 @@
 package com.contentgrid.gateway;
 
+import java.time.Duration;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -9,5 +10,5 @@ public class ServiceDiscoveryProperties {
 
     private boolean enabled = false;
     private String namespace = "default";
-    private long resync = 60;
+    private Duration resync = Duration.ofMinutes(1);
 }


### PR DESCRIPTION
This reduces the amount of logs emitted for all discovered services,
while still logging when a new service has been discovered (or when it
has changed).
