### PR TITLE
[ACC-2977] Ensure that only a single value is sent for X-Forwarded-Proto

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
             - Abac
           # This looks unsafe, but the gateway is always supposed to be deployed behind a proxy that _replaces_ X-Forwarded-For/Forwarded headers with only trusted addresses
           trusted-proxies: .*
+          x-forwarded:
+            proto-append: false # uvicorn (for the assistant) doesn't support a comma-separated list for X-Forwarded-Proto: https://github.com/Kludex/uvicorn/pull/2104; and only sending a single value should be fine for all services
 
 management:
   endpoints:


### PR DESCRIPTION
Uvicorn does not support multiple values present in X-Forwarded-Proto;
but the gateway does append an extra value by default, because the
upstream proxy has already set X-Forwarded-Proto.

Keeping a single value (the one set by the gateway) is fine; because the
gateway already derives the protocol correctly from the upstream proxy headers.
